### PR TITLE
fix: wrap react day picker with custom overlay

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "react-error-boundary": "3.1.3",
     "react-i18next": "11.12.0",
     "react-icons": "4.3.1",
+    "react-popper": "2.2.5",
     "react-query": "3.29.0",
     "react-router-dom": "5.3.0",
     "react-select": "5.1.0",

--- a/src/components/DayPicker/index.tsx
+++ b/src/components/DayPicker/index.tsx
@@ -70,6 +70,7 @@ const CustomDayPickerOverlay = forwardRef<CustomDayPickerOverlayProps, 'div'>(
           ref={setPopperElement}
           className={classNames.overlay}
           style={styles.popper}
+          zIndex="dayPicker"
           {...attributes.popper}
         >
           {children}

--- a/src/components/DayPicker/index.tsx
+++ b/src/components/DayPicker/index.tsx
@@ -1,6 +1,7 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 
 import {
+  chakra,
   Box,
   BoxProps,
   Input,
@@ -16,6 +17,7 @@ import { DayModifiers } from 'react-day-picker';
 import DayPickerInput from 'react-day-picker/DayPickerInput';
 import { useTranslation } from 'react-i18next';
 import { FiCalendar } from 'react-icons/fi';
+import { usePopper } from 'react-popper';
 
 import { Icon } from '@/components';
 
@@ -34,6 +36,45 @@ const ReactDayPickerInput = forwardRef<InputProps, 'input'>(
       <Input ref={ref} {...rest} />
     </InputGroup>
   )
+);
+
+// DISCLAIMER: This code is written using v7 of react-day-picker. Here are some
+// code comments containing permalinks to the v7 documentation as the website
+// will move in a near future.
+
+// On v7, react-day-picker doesn't provide typings. Following typings are based
+// on the proptypes in the source code.
+// https://github.com/gpbl/react-day-picker/blob/v7/src/DayPickerInput.js#L32
+interface CustomDayPickerOverlayProps {
+  input?: any;
+  classNames?: Record<string, string>;
+}
+
+// The CustomOverlay to control the way the day picker is displayed
+// https://github.com/gpbl/react-day-picker/blob/v7/docs/src/code-samples/examples/input-custom-overlay.js
+// Check the following permalink for v7 props documentation
+// https://github.com/gpbl/react-day-picker/blob/750f6cd808b2ac29772c8df5c497a66e818080e8/docs/src/pages/api/DayPickerInput.js#L163
+const CustomDayPickerOverlay = forwardRef<CustomDayPickerOverlayProps, 'div'>(
+  ({ children, input, classNames, ...props }, ref) => {
+    const [popperElement, setPopperElement] = useState(null);
+
+    const { styles, attributes } = usePopper(input, popperElement, {
+      placement: 'bottom-start',
+    });
+
+    return (
+      <chakra.div className={classNames.overlayWrapper} {...props} ref={ref}>
+        <chakra.div
+          ref={setPopperElement}
+          className={classNames.overlay}
+          style={styles.popper}
+          {...attributes.popper}
+        >
+          {children}
+        </chakra.div>
+      </chakra.div>
+    );
+  }
 );
 
 interface DayPickerProps extends Omit<BoxProps, 'onChange'> {
@@ -110,6 +151,7 @@ export const DayPicker: FC<DayPickerProps> = ({
           readOnly: isSmartphoneFormat,
           ...inputProps,
         }}
+        overlayComponent={CustomDayPickerOverlay}
       />
     </Box>
   );

--- a/src/components/DayPicker/index.tsx
+++ b/src/components/DayPicker/index.tsx
@@ -46,6 +46,8 @@ const ReactDayPickerInput = forwardRef<InputProps, 'input'>(
 // on the proptypes in the source code.
 // https://github.com/gpbl/react-day-picker/blob/v7/src/DayPickerInput.js#L32
 interface CustomDayPickerOverlayProps {
+  selectedDay?: Date;
+  month?: Date;
   input?: any;
   classNames?: Record<string, string>;
 }
@@ -55,7 +57,7 @@ interface CustomDayPickerOverlayProps {
 // Check the following permalink for v7 props documentation
 // https://github.com/gpbl/react-day-picker/blob/750f6cd808b2ac29772c8df5c497a66e818080e8/docs/src/pages/api/DayPickerInput.js#L163
 const CustomDayPickerOverlay = forwardRef<CustomDayPickerOverlayProps, 'div'>(
-  ({ children, input, classNames, ...props }, ref) => {
+  ({ children, input, classNames, selectedDay, month, ...props }, ref) => {
     const [popperElement, setPopperElement] = useState(null);
 
     const { styles, attributes } = usePopper(input, popperElement, {
@@ -144,7 +146,7 @@ export const DayPicker: FC<DayPickerProps> = ({
               .day(i + 1)
               .format('dd')
           ),
-          firstDayOfWeek: 1,
+          firstDayOfWeek: 0,
           ...dayPickerProps,
         }}
         inputProps={{

--- a/src/theme/externals/reactDayPicker.ts
+++ b/src/theme/externals/reactDayPicker.ts
@@ -5,6 +5,7 @@ export const reactDayPicker = (props) => ({
   '.DayPicker *': {
     outline: 'none',
   },
+
   '.DayPickerInput': {
     display: 'inline-block',
     fontSize: '0.1em',
@@ -61,21 +62,11 @@ export const reactDayPicker = (props) => ({
     color: 'gray.300',
   },
 
-  '.DayPicker:not(.DayPicker--interactionDisabled)': {
-    '.DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--selected):not(.DayPicker-Day--outside):hover':
-      {
-        backgroundColor: mode('blackAlpha.200', 'whiteAlpha.200')(props),
-        borderRadius: '100%',
-        color: mode('black', 'white')(props),
-      },
-  },
-
   '.DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside)':
     {
       position: 'relative',
       backgroundColor: mode('brand.500', 'brand.600')(props),
       borderRadius: '100%',
-      color: mode('black', 'white')(props),
     },
 
   '.DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside):hover':
@@ -84,6 +75,15 @@ export const reactDayPicker = (props) => ({
       borderRadius: '100%',
       color: 'white',
     },
+
+  '.DayPicker:not(.DayPicker--interactionDisabled)': {
+    '.DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--selected):not(.DayPicker-Day--outside):hover':
+      {
+        backgroundColor: mode('blackAlpha.200', 'whiteAlpha.200')(props),
+        borderRadius: '100%',
+        color: mode('black', 'white')(props),
+      },
+  },
 
   '.DayPicker-Day--weekend:.DayPicker-Day--selected': {
     color: 'white',

--- a/src/theme/externals/reactDayPicker.ts
+++ b/src/theme/externals/reactDayPicker.ts
@@ -2,6 +2,9 @@ import { mode } from '@chakra-ui/theme-tools';
 import 'react-day-picker/lib/style.css';
 
 export const reactDayPicker = (props) => ({
+  '.DayPicker *': {
+    outline: 'none',
+  },
   '.DayPickerInput': {
     display: 'inline-block',
     fontSize: '0.1em',
@@ -14,7 +17,7 @@ export const reactDayPicker = (props) => ({
     right: { base: 0, sm: 'auto' },
     marginLeft: 'auto',
     marginRight: 'auto',
-    marginTop: '3em',
+    top: '3em',
     width: '100%',
     maxWidth: '90vw',
   },
@@ -34,26 +37,29 @@ export const reactDayPicker = (props) => ({
     border: '1px solid',
     borderColor: mode('gray.200', 'gray.900')(props),
     borderRadius: 'md',
-    maxWidth: '90vw',
+    width: 'min-content',
   },
 
-  '.DayPicker-Day--disabled': {
+  '.DayPicker-Months': {
+    display: 'grid',
+    gridTemplateColumns: {
+      base: 'repeat(1, 1fr)',
+      md: 'repeat(2, 1fr)',
+      xl: 'repeat(4, 1fr)',
+    },
+  },
+
+  '.DayPicker-Day--outside': {
+    backgroundColor: 'transparent!important',
+  },
+
+  '.DayPicker-Day--disabled, .DayPicker-Day--today.DayPicker-Day--disabled': {
     pointerEvents: 'none',
   },
 
-  '.DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside)':
-    {
-      position: 'relative',
-      backgroundColor: mode('brand.500', 'brand.600')(props),
-      borderRadius: '100%',
-    },
-
-  '.DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside):hover':
-    {
-      backgroundColor: mode('brand.400', 'brand.500')(props),
-      borderRadius: '100%',
-      color: 'white',
-    },
+  '.DayPicker-Day--today.DayPicker-Day--disabled': {
+    color: 'gray.300',
+  },
 
   '.DayPicker:not(.DayPicker--interactionDisabled)': {
     '.DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--selected):not(.DayPicker-Day--outside):hover':
@@ -64,12 +70,38 @@ export const reactDayPicker = (props) => ({
       },
   },
 
+  '.DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside)':
+    {
+      position: 'relative',
+      backgroundColor: mode('brand.500', 'brand.600')(props),
+      borderRadius: '100%',
+      color: mode('black', 'white')(props),
+    },
+
+  '.DayPicker-Day--selected:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside):hover':
+    {
+      backgroundColor: mode('brand.400', 'brand.500')(props),
+      borderRadius: '100%',
+      color: 'white',
+    },
+
+  '.DayPicker-Day--weekend:.DayPicker-Day--selected': {
+    color: 'white',
+  },
+
+  '.DayPicker-Day--weekend': {
+    color: 'gray.400',
+  },
+
   '.DayPicker-Day': {
+    display: 'block',
     borderRadius: 'full',
     cursor: 'pointer',
-    height: '2.8em',
-    width: '2.8em',
+    height: '2rem',
+    minWidth: '2rem',
     transition: '0.2s',
+    padding: 0,
+    lineHeight: '2rem',
   },
 
   '.DayPicker-Day--today': {
@@ -77,14 +109,38 @@ export const reactDayPicker = (props) => ({
     fontWeight: 'bold',
   },
 
+  '.DayPicker-Caption': {
+    display: 'block',
+  },
+
   '.DayPicker-Caption > div': {
     fontWeight: '400',
     fontSize: '1em',
   },
 
+  '.DayPicker-Weekdays': {
+    display: 'block',
+  },
+
+  '.DayPicker-WeekdaysRow': {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(7, 1fr)',
+  },
+
   '.DayPicker-Weekday': {
+    display: 'block',
     fontWeight: '350',
     color: mode('black', 'white')(props),
     fontSize: '0.875em',
+  },
+
+  '.DayPicker-Body': {
+    display: 'grid',
+  },
+
+  '.DayPicker-Week': {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(7, 1fr)',
+    gridGap: '0.1rem',
   },
 });

--- a/src/theme/foundations/index.ts
+++ b/src/theme/foundations/index.ts
@@ -3,6 +3,7 @@ import { layout } from './layout';
 import { shadows } from './shadows';
 import { spacing } from './spacing';
 import { typography } from './typography';
+import { zIndices } from './z-index';
 
 const foundations = {
   colors,
@@ -10,6 +11,7 @@ const foundations = {
   shadows,
   space: spacing,
   layout,
+  zIndices,
 };
 
 export default foundations;

--- a/src/theme/foundations/z-index.ts
+++ b/src/theme/foundations/z-index.ts
@@ -1,0 +1,4 @@
+// https://chakra-ui.com/docs/theming/theme#z-index-values
+export const zIndices = {
+  dayPicker: 1650,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -12067,7 +12067,7 @@ react-popper-tooltip@^3.1.1:
     "@popperjs/core" "^2.5.4"
     react-popper "^2.2.4"
 
-react-popper@^2.2.4:
+react-popper@2.2.5, react-popper@^2.2.4:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.5.tgz#1214ef3cec86330a171671a4fbcbeeb65ee58e96"
   integrity sha512-kxGkS80eQGtLl18+uig1UIf9MKixFSyPxglsgLBxlYnyDf65BiY9B3nZSc6C9XUNDgStROB0fMQlTEz1KxGddw==


### PR DESCRIPTION
this custom overlay use react popper to position react day picker correctly

> 💡 Also improve style.

# Before

![image](https://user-images.githubusercontent.com/3920615/133121011-5a7127de-0ec3-4caa-81cc-fc66a60a6506.png)

# After

![image](https://user-images.githubusercontent.com/3920615/133121083-29920f8d-a0a4-4a11-a715-79da75f9e8eb.png)
