### PR TITLE
Fix: wrong localization of connection interceptor title in french

### DIFF
--- a/src/locales/fr/auth.json
+++ b/src/locales/fr/auth.json
@@ -14,7 +14,7 @@
     }
   },
   "interceptor": {
-    "title": "Connectez-vous nécessaire",
+    "title": "Connexion nécessaire",
     "description": "Veuillez vous connecter pour continuer"
   },
   "data": {


### PR DESCRIPTION
## Description

The localization for the key `auth:interceptor.title` is not correct in french.

![Capture d’écran du 2022-01-18 15-01-58](https://user-images.githubusercontent.com/38964092/149952716-ec99607e-13f7-49f8-8139-9cac0f8fb579.png)