### PR TITLE
fix: replace postinstall npm script with prepare

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "description": "Opinionated UI starter with ⚛️ React, ⚡️ Chakra UI, ⚛️ React Query & 🐜 Formiz — From the 🐻 BearStudio Team",
   "scripts": {
-    "postinstall": "husky install",
+    "prepare": "husky install",
     "test": "jest --roots src --watch",
     "dev": "yarn docs:build && next dev",
     "build": "yarn docs:build && next build",


### PR DESCRIPTION
This PR aims to fix build issues on CI / Serverless environments

This is the recommended way of installing husky (https://typicode.github.io/husky/#/?id=install)