### PR TITLE
Enforce node engine 14.17+, yarn 1.22+ and types checking on lint script

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "private": true,
   "version": "1.0.0",
   "description": "Opinionated UI starter with ⚛️ React, ⚡️ Chakra UI, ⚛️ React Query & 🐜 Formiz — From the 🐻 BearStudio Team",
+  "engines": {
+    "node": ">=14.17",
+    "npm": "please-use-yarn",
+    "yarn": ">=1.22"
+  },
   "scripts": {
     "prepare": "husky install",
     "test": "jest --roots src --watch",
@@ -10,7 +15,7 @@
     "build": "yarn docs:build && next build",
     "start": "next start",
     "pretty": "prettier -w .",
-    "lint": "eslint ./src --fix",
+    "lint": "eslint ./src --fix && tsc --noEmit",
     "storybook": "start-storybook -p 6006",
     "storybook:build": "build-storybook && mv ./storybook-static ./public/storybook",
     "static:build": "yarn build && next export",
@@ -19,7 +24,7 @@
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,json}": "prettier --write",
-    "*.{ts,tsx,js,jsx}": "eslint --cache --fix",
+    "*.{ts,tsx,js,jsx}": "eslint --cache --fix && tsc --noEmit",
     "src/mocks/**/*.{yaml,yml}": "yarn docs:build"
   },
   "dependencies": {


### PR DESCRIPTION
Enforce node engine 14.17+, yarn 1.22+ and types checking on lint script

Fix #152 