### PR TITLE
feat: add generic type folder and Overwrite type

### DIFF
--- a/src/components/DayPicker/index.tsx
+++ b/src/components/DayPicker/index.tsx
@@ -80,13 +80,15 @@ const CustomDayPickerOverlay = forwardRef<CustomDayPickerOverlayProps, 'div'>(
   }
 );
 
-interface DayPickerProps extends Omit<BoxProps, 'onChange'> {
+type CustomProps = {
   placeholder?: string;
   value?: string | Date | null;
   onChange?: (date: Date | null | undefined, isValid: boolean) => void;
   inputProps?: InputProps;
   dayPickerProps?: DayPickerProps;
-}
+};
+
+interface DayPickerProps extends Overwrite<BoxProps, CustomProps> {}
 
 export const DayPicker: FC<DayPickerProps> = ({
   placeholder = FORMAT,

--- a/src/types/utilities.d.ts
+++ b/src/types/utilities.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Use this type to overwrite the keys of the first type with the second one.
+ * This is mainly useful with custom props type that extends multiple components
+ * with the `as` props.
+ */
+type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "paths": {
       "@/*": ["src/*"]
     },
-    "incremental": true
+    "incremental": true,
+    "typeRoots": ["node_modules/@types", "src/types"]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Example:

```ts
type CustomProps = {
  placeholder?: string;
  value?: string | Date | null;
  onChange?: (date: Date | null | undefined, isValid: boolean) => void;
  inputProps?: InputProps;
  dayPickerProps?: DayPickerProps;
};

interface DayPickerProps extends Overwrite<BoxProps, CustomProps> {}
```

To avoid the `Omit` on every keys each time we add a new key in the custom props type.

```ts
interface DayPickerProps extends Omit<BoxProps, 'onChange'>  {
  placeholder?: string;
  value?: string | Date | null;
  onChange?: (date: Date | null | undefined, isValid: boolean) => void;
  inputProps?: InputProps;
  dayPickerProps?: DayPickerProps;
};
```