### PR TITLE
fix: don't send API token to external API

### DIFF
--- a/src/config/axios.ts
+++ b/src/config/axios.ts
@@ -5,8 +5,9 @@ import { isBrowser } from '@/utils/ssr';
 
 Axios.interceptors.request.use(
   (config: AxiosRequestConfig) => {
+    const isExternal = !!config?.url?.startsWith('http');
     const token = isBrowser ? localStorage.getItem(AUTH_TOKEN_KEY) : null;
-    const authHeaders = token ? { Authorization: `Bearer ${token}` } : {};
+    const authHeaders = token && !isExternal ? { Authorization: `Bearer ${token}` } : {};
     return {
       baseURL: process.env.NEXT_PUBLIC_API_BASE_URL || '/api',
       ...config,


### PR DESCRIPTION
With this fix. We don't send Authorization token to external API. (More important if we send request on HTTP only not HTTPS public API)

It's better because we can send request to public external API and forget to remove it.

Or we can have bug because we use other authentification methods. (I had this case with Cloudinary)