### PR TITLE
fix: add manually isDisabled to Checkbox component

### DIFF
--- a/src/components/FieldBooleanCheckbox/index.tsx
+++ b/src/components/FieldBooleanCheckbox/index.tsx
@@ -20,6 +20,7 @@ export const FieldBooleanCheckbox = (props: FieldBooleanCheckboxProps) => {
     helper,
     optionLabel,
     size = 'md',
+    isDisabled,
     ...otherProps
   } = props;
   const [isTouched, setIsTouched] = useState(false);
@@ -34,6 +35,7 @@ export const FieldBooleanCheckbox = (props: FieldBooleanCheckboxProps) => {
     helper,
     id,
     isRequired: !!required,
+    isDisabled,
     label,
     showError,
     ...otherProps,
@@ -45,6 +47,7 @@ export const FieldBooleanCheckbox = (props: FieldBooleanCheckboxProps) => {
         id={id}
         size={size}
         value={value ?? false}
+        isDisabled={isDisabled}
         onChange={() => setValue(!value)}
       >
         {optionLabel || <>&nbsp;</>}


### PR DESCRIPTION
By default "isDisabled" props is not appliqued on Checkbox input

Surely because by default ChakraUI need CheckboxProvider (?)

To fix I applied mannually isDisabled props