### PR TITLE
Feat: Add ConfirmPopover component

### DIFF
--- a/src/components/ConfirmPopover/docs.stories.tsx
+++ b/src/components/ConfirmPopover/docs.stories.tsx
@@ -10,26 +10,22 @@ export default {
 
 export const Default = () => {
   return (
-    <>
-      <ConfirmPopover onConfirm={() => alert('Custom Action')}>
-        <Button>Trigger Popover</Button>
-      </ConfirmPopover>
-    </>
+    <ConfirmPopover onConfirm={() => alert('Custom Action')}>
+      <Button>Trigger Popover</Button>
+    </ConfirmPopover>
   );
 };
 
 export const WithCustomParameters = () => {
   return (
-    <>
-      <ConfirmPopover
-        title="Popover Title"
-        message={'Custom message'}
-        onConfirm={() => alert('Custom Action')}
-        confirmText="Custom Text"
-        confirmVariant="@danger"
-      >
-        <Button>Trigger Popover</Button>
-      </ConfirmPopover>
-    </>
+    <ConfirmPopover
+      title="Popover Title"
+      message="Custom message"
+      onConfirm={() => alert('Custom Action')}
+      confirmText="Custom Text"
+      confirmVariant="@danger"
+    >
+      <Button>Trigger Popover</Button>
+    </ConfirmPopover>
   );
 };

--- a/src/components/ConfirmPopover/docs.stories.tsx
+++ b/src/components/ConfirmPopover/docs.stories.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import { Button } from '@chakra-ui/react';
+
+import { ConfirmPopover } from '.';
+
+export default {
+  title: 'Components/ConfirmPopover',
+};
+
+export const Default = () => {
+  return (
+    <>
+      <ConfirmPopover onConfirm={() => alert('Custom Action')}>
+        <Button>Trigger Popover</Button>
+      </ConfirmPopover>
+    </>
+  );
+};
+
+export const WithCustomParameters = () => {
+  return (
+    <>
+      <ConfirmPopover
+        title="Popover Title"
+        message={'Custom message'}
+        onConfirm={() => alert('Custom Action')}
+        confirmText="Custom Text"
+        confirmVariant="@danger"
+      >
+        <Button>Trigger Popover</Button>
+      </ConfirmPopover>
+    </>
+  );
+};

--- a/src/components/ConfirmPopover/index.tsx
+++ b/src/components/ConfirmPopover/index.tsx
@@ -1,0 +1,97 @@
+import React, { ReactNode, useRef } from 'react';
+
+import {
+  Button,
+  ButtonGroup,
+  HStack,
+  Heading,
+  Popover,
+  PopoverArrow,
+  PopoverBody,
+  PopoverContent,
+  PopoverFooter,
+  PopoverProps,
+  PopoverTrigger,
+  Portal,
+  useDisclosure,
+} from '@chakra-ui/react';
+import FocusLock from 'react-focus-lock';
+import { useTranslation } from 'react-i18next';
+
+interface ConfirmPopoverProps extends PopoverProps {
+  children: ReactNode;
+  title?: ReactNode;
+  message?: ReactNode;
+  onConfirm(): void;
+  confirmText?: ReactNode;
+  confirmVariant?: string;
+}
+
+export const ConfirmPopover: React.FC<ConfirmPopoverProps> = ({
+  children,
+  title,
+  message,
+  onConfirm,
+  confirmText,
+  confirmVariant = '@primary',
+  ...rest
+}) => {
+  const { t } = useTranslation();
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  const displayHeading =
+    !title && !message ? t('components:confirmPopover.heading') : title;
+
+  const initialFocusRef = useRef<TODO>();
+
+  return (
+    <>
+      <Popover
+        isLazy
+        isOpen={isOpen}
+        onClose={onClose}
+        onOpen={onOpen}
+        initialFocusRef={initialFocusRef}
+        {...rest}
+      >
+        <PopoverTrigger>{children}</PopoverTrigger>
+        <Portal>
+          <PopoverContent>
+            <FocusLock returnFocus persistentFocus={false}>
+              <PopoverArrow />
+              <PopoverBody fontSize="sm">
+                {displayHeading && (
+                  <Heading size="sm" mb={message ? 2 : 0}>
+                    {displayHeading}
+                  </Heading>
+                )}
+                {message}
+              </PopoverBody>
+              <PopoverFooter>
+                <HStack>
+                  <ButtonGroup justifyContent="space-between" flex="1">
+                    <Button size="sm" onClick={onClose}>
+                      {t('common:actions.cancel')}
+                    </Button>
+                    <Button
+                      variant={confirmVariant}
+                      size="sm"
+                      onClick={() => {
+                        onConfirm();
+                        onClose();
+                      }}
+                      ref={initialFocusRef}
+                    >
+                      {confirmText ??
+                        t('components:confirmPopover.confirmText')}
+                    </Button>
+                  </ButtonGroup>
+                </HStack>
+              </PopoverFooter>
+            </FocusLock>
+          </PopoverContent>
+        </Portal>
+      </Popover>
+    </>
+  );
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,6 @@
 export * from './ActionsButton';
 export * from './ConfirmMenuItem';
+export * from './ConfirmPopover';
 export * from './DataList';
 export * from './DateAgo';
 export * from './DateSelector';

--- a/src/locales/ar/components.json
+++ b/src/locales/ar/components.json
@@ -8,6 +8,10 @@
   "confirmMenuItem": {
     "confirmText": "انقر للتأكيد"
   },
+  "confirmPopover": {
+    "confirmText": "أكد",
+    "heading": "اهل انت متأكد ؟"
+  },
   "pagination": {
     "firstPage": "الصفحة الأولى",
     "prevPage": "الصفحة السابقة",

--- a/src/locales/en/components.json
+++ b/src/locales/en/components.json
@@ -10,7 +10,7 @@
   },
   "confirmPopover": {
     "confirmText": "Confirm",
-    "heading": "Are you sure ?"
+    "heading": "Are you sure?"
   },
   "pagination": {
     "showing": "<box>Showing</box> <strong>{{firstItemOnPage}}</strong> <span>to</span> <strong>{{lastItemOnPage}}</strong> <span>of</span> <strong>{{totalItems}}</strong> <box>results</box>",

--- a/src/locales/en/components.json
+++ b/src/locales/en/components.json
@@ -8,6 +8,10 @@
   "confirmMenuItem": {
     "confirmText": "Click to confirm"
   },
+  "confirmPopover": {
+    "confirmText": "Confirm",
+    "heading": "Are you sure ?"
+  },
   "pagination": {
     "showing": "<box>Showing</box> <strong>{{firstItemOnPage}}</strong> <span>to</span> <strong>{{lastItemOnPage}}</strong> <span>of</span> <strong>{{totalItems}}</strong> <box>results</box>",
     "loading": "<spinner></spinner> <box>Loading</box> <strong>{{firstItemOnPage}}</strong> <span>to</span> <strong>{{lastItemOnPage}}</strong> <span>of</span> <strong>{{totalItems}}</strong> <box>results</box>",

--- a/src/locales/fr/components.json
+++ b/src/locales/fr/components.json
@@ -8,6 +8,10 @@
   "confirmMenuItem": {
     "confirmText": "Cliquer pour confirmer"
   },
+  "confirmPopover": {
+    "confirmText": "Confirmer",
+    "heading": "Etes-vous sûr ?"
+  },
   "pagination": {
     "firstPage": "Première page",
     "lastPage": "Dernière page",


### PR DESCRIPTION
Add new ConfirmPopover component, with docs stories and translations

<img width="352" alt="Capture d’écran 2022-03-18 à 22 04 26" src="https://user-images.githubusercontent.com/48803115/159082880-d14155dd-99f7-4e27-9b2f-47c6c3f6041b.png">
