### PR TITLE
added isFixed props to PageTopBar with exemple in story

### DIFF
--- a/src/app/layout/Page/docs.stories.tsx
+++ b/src/app/layout/Page/docs.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Flex } from '@chakra-ui/react';
+import { Center, Flex } from '@chakra-ui/react';
 
 import { Layout } from '@/app/layout';
 
@@ -40,6 +40,20 @@ export const FocusAndBackButton = () => (
       Page Top Bar
     </PageTopBar>
     <PageContent>Page Content</PageContent>
+    <PageBottomBar>Page Bottom Bar</PageBottomBar>
+  </Page>
+);
+
+export const FocusFixedPageTopBar = () => (
+  <Page isFocusMode>
+    <PageTopBar showBack isFixed onBack={() => alert('Back')}>
+      Page Top Bar
+    </PageTopBar>
+    <PageContent>
+      <Center h={800} borderWidth={1}>
+        Page Content
+      </Center>
+    </PageContent>
     <PageBottomBar>Page Bottom Bar</PageBottomBar>
   </Page>
 );

--- a/src/app/layout/Page/docs.stories.tsx
+++ b/src/app/layout/Page/docs.stories.tsx
@@ -58,6 +58,22 @@ export const FocusFixedPageTopBar = () => (
   </Page>
 );
 
+export const FixedPageTopBar = () => (
+  <Layout>
+    <Page>
+      <PageTopBar showBack isFixed onBack={() => alert('Back')}>
+        Page Top Bar
+      </PageTopBar>
+      <PageContent>
+        <Center h={800} borderWidth={1}>
+          Page Content
+        </Center>
+      </PageContent>
+      <PageBottomBar>Page Bottom Bar</PageBottomBar>
+    </Page>
+  </Layout>
+);
+
 export const ContainerSizeSmall = () => (
   <Page containerSize="sm">
     <PageTopBar>Page Top Bar</PageTopBar>

--- a/src/app/layout/Page/docs.stories.tsx
+++ b/src/app/layout/Page/docs.stories.tsx
@@ -58,22 +58,6 @@ export const FocusFixedPageTopBar = () => (
   </Page>
 );
 
-export const FixedPageTopBar = () => (
-  <Layout>
-    <Page>
-      <PageTopBar showBack isFixed onBack={() => alert('Back')}>
-        Page Top Bar
-      </PageTopBar>
-      <PageContent>
-        <Center h={800} borderWidth={1}>
-          Page Content
-        </Center>
-      </PageContent>
-      <PageBottomBar>Page Bottom Bar</PageBottomBar>
-    </Page>
-  </Layout>
-);
-
 export const ContainerSizeSmall = () => (
   <Page containerSize="sm">
     <PageTopBar>Page Top Bar</PageTopBar>

--- a/src/app/layout/Page/index.tsx
+++ b/src/app/layout/Page/index.tsx
@@ -7,11 +7,14 @@ import {
   HStack,
   IconButton,
   Stack,
+  useTheme,
 } from '@chakra-ui/react';
 import { FiArrowLeft, FiArrowRight } from 'react-icons/fi';
 
 import { useFocusMode } from '@/app/layout';
 import { useRtl } from '@/hooks/useRtl';
+
+import { useLayoutContext } from '../LayoutContext';
 
 type PageContextValue = {
   nav: React.ReactNode;
@@ -52,44 +55,67 @@ const PageContainer = ({ children, ...rest }: FlexProps) => {
 type PageTopBarProps = FlexProps & {
   onBack?(): void;
   showBack?: boolean;
+  isFixed?: boolean;
 };
 
 export const PageTopBar = ({
   children,
   onBack = () => undefined,
   showBack = false,
+  isFixed = false,
   ...rest
 }: PageTopBarProps) => {
+  const topBarRef = useRef<HTMLDivElement>(null);
+  const [height, setHeight] = useState(0);
+  const { isFocusMode } = useLayoutContext();
+  const theme = useTheme();
+
+  useLayoutEffect(() => {
+    const onResize = () => {
+      setHeight(topBarRef.current?.offsetHeight || 0);
+    };
+    onResize();
+    window.addEventListener('resize', onResize);
+    return () => {
+      window.removeEventListener('resize', onResize);
+    };
+  }, []);
+
   const { rtlValue } = useRtl();
 
   return (
-    <Flex
-      zIndex="2"
-      direction="column"
-      pt="4"
-      pb="4"
-      boxShadow="0 4px 20px rgba(0, 0, 0, 0.05)"
-      bg="white"
-      _dark={{ bg: 'gray.900' }}
-      {...rest}
-    >
-      <Box w="full" h="0" pb="safe-top" />
-      <PageContainer>
-        <HStack spacing="4">
-          {showBack && (
-            <Box ms={{ base: 0, lg: '-3.5rem' }}>
-              <IconButton
-                aria-label="Go Back"
-                icon={rtlValue(<FiArrowLeft />, <FiArrowRight />)}
-                variant="ghost"
-                onClick={() => onBack()}
-              />
-            </Box>
-          )}
-          <Box flex="1">{children}</Box>
-        </HStack>
-      </PageContainer>
-    </Flex>
+    <>
+      {isFixed && <Box h={`${height}px`} />}
+      <Flex
+        zIndex="2"
+        direction="column"
+        pt="4"
+        pb="4"
+        boxShadow="0 4px 20px rgba(0, 0, 0, 0.05)"
+        bg="white"
+        ref={topBarRef}
+        top={isFocusMode ? 0 : theme.layout.topBar.height}
+        style={isFixed ? { position: 'fixed', right: '0', left: '0' } : {}}
+        {...rest}
+      >
+        <Box w="full" h="0" pb="safe-top" />
+        <PageContainer>
+          <HStack spacing="4">
+            {showBack && (
+              <Box ms={{ base: 0, lg: '-3.5rem' }}>
+                <IconButton
+                  aria-label="Go Back"
+                  icon={rtlValue(<FiArrowLeft />, <FiArrowRight />)}
+                  variant="ghost"
+                  onClick={() => onBack()}
+                />
+              </Box>
+            )}
+            <Box flex="1">{children}</Box>
+          </HStack>
+        </PageContainer>
+      </Flex>
+    </>
   );
 };
 

--- a/src/app/layout/Page/index.tsx
+++ b/src/app/layout/Page/index.tsx
@@ -93,11 +93,16 @@ export const PageTopBar = ({
         pb="4"
         boxShadow="0 4px 20px rgba(0, 0, 0, 0.05)"
         bg="white"
-        top={!isFocusMode && isFixed ? theme.layout.topBar.height : 0}
-        ref={isFixed ? topBarRef : null}
-        position={isFixed ? 'fixed' : {}}
-        right={isFixed ? '0' : {}}
-        left={isFixed ? '0' : {}}
+        ref={topBarRef}
+        _dark={{ bg: 'gray.900' }}
+        {...(isFixed
+          ? {
+              top: !isFocusMode ? theme.layout.topBar.height : '0',
+              position: 'fixed',
+              right: '0',
+              left: '0',
+            }
+          : {})}
         {...rest}
       >
         <Box w="full" h="0" pb="safe-top" />

--- a/src/app/layout/Page/index.tsx
+++ b/src/app/layout/Page/index.tsx
@@ -11,10 +11,8 @@ import {
 } from '@chakra-ui/react';
 import { FiArrowLeft, FiArrowRight } from 'react-icons/fi';
 
-import { useFocusMode } from '@/app/layout';
+import { useFocusMode, useLayoutContext } from '@/app/layout';
 import { useRtl } from '@/hooks/useRtl';
-
-import { useLayoutContext } from '../LayoutContext';
 
 type PageContextValue = {
   nav: React.ReactNode;
@@ -71,15 +69,17 @@ export const PageTopBar = ({
   const theme = useTheme();
 
   useLayoutEffect(() => {
-    const onResize = () => {
-      setHeight(topBarRef.current?.offsetHeight || 0);
-    };
-    onResize();
-    window.addEventListener('resize', onResize);
-    return () => {
-      window.removeEventListener('resize', onResize);
-    };
-  }, []);
+    if (isFixed) {
+      const onResize = () => {
+        setHeight(topBarRef.current?.offsetHeight || 0);
+      };
+      onResize();
+      window.addEventListener('resize', onResize);
+      return () => {
+        window.removeEventListener('resize', onResize);
+      };
+    }
+  }, [isFixed]);
 
   const { rtlValue } = useRtl();
 
@@ -93,9 +93,11 @@ export const PageTopBar = ({
         pb="4"
         boxShadow="0 4px 20px rgba(0, 0, 0, 0.05)"
         bg="white"
-        ref={topBarRef}
-        top={isFocusMode ? 0 : theme.layout.topBar.height}
-        style={isFixed ? { position: 'fixed', right: '0', left: '0' } : {}}
+        top={!isFocusMode && isFixed ? theme.layout.topBar.height : 0}
+        ref={isFixed ? topBarRef : null}
+        position={isFixed ? 'fixed' : {}}
+        right={isFixed ? '0' : {}}
+        left={isFixed ? '0' : {}}
         {...rest}
       >
         <Box w="full" h="0" pb="safe-top" />


### PR DESCRIPTION
## Description

Component PageTopBar is used when there is a need to add a TopBar to a specific page in addition to the standard TopBar providede by the Layout.

Right now, the PageTopBar places itself under the Layout TopBar. When the page is scrolled, the PageTopBar is scrolled with it and goes hiding behind the LayoutTopBar.

## Implementation

This PR adds a new `isFixed:boolean` props to the PageTopBar. It's default value is `false` to keep the previously described behaviour. When set to `true`, the PageTopBar will stay under the Layout TopBar even when the page content is scrolled.

An exemple is added in storybook : App Layout > Page > Focus Fixed PageTopBar.

TL,DR : Added isFixed props to PageTopBar, fixes the PageTopBar right under the Layout TopBar if set to `true`.

## Exemple

https://user-images.githubusercontent.com/98312420/165907389-7ea49969-ccc8-4ef6-bfd9-3a170dbb6aca.mp4



