### PR TITLE
fix wording at the test of ActionsButton

### DIFF
--- a/src/components/ActionsButton/ActionsButton.cy.tsx
+++ b/src/components/ActionsButton/ActionsButton.cy.tsx
@@ -6,7 +6,7 @@ describe('ActionsButton', () => {
   const actionsButtonSelector = '[data-test="actions-button"]';
   const menuListSelector = '[data-test="menu-list"]';
 
-  it('should display an accecible clickable icon', () => {
+  it('should display an accessible clickable icon', () => {
     cy.mount(
       <Menu>
         <MenuButton as={ActionsButton} />


### PR DESCRIPTION
## Description
We have a test Cypres at the file `ActionsButton.cy.tsx`, with test description `should display an accecible clickable icon`, as we see the word accessible is written wrong.
## Issue Link 

closes #232 

## TODO
- [x] Changing the description of the Cypress test, which was written wrong,I will change it from `accecible` to `accessible`.
The file that i will edite is  `ActionsButton.cy.tsx`, is exist at `src/components/ActionsButton/ActionsButton.cy.tsx`