### PR TITLE
Change hard coded strings to const for routing and API error keys

### DIFF
--- a/src/app/account/account.service.ts
+++ b/src/app/account/account.service.ts
@@ -42,10 +42,15 @@ export const useAccount = (
   return { account, isAdmin, ...rest };
 };
 
+type AccountError = {
+  title: string;
+  errorKey: 'userexists' | 'emailexists';
+};
+
 export const useCreateAccount = (
   config: UseMutationOptions<
     Account,
-    AxiosError,
+    AxiosError<AccountError>,
     Pick<Account, 'login' | 'email' | 'langKey'> & { password: string }
   > = {}
 ) => {

--- a/src/app/admin/users/users.service.ts
+++ b/src/app/admin/users/users.service.ts
@@ -12,7 +12,7 @@ import { DEFAULT_LANGUAGE_KEY } from '@/constants/i18n';
 
 type UserMutateError = {
   title: string;
-  errorKey: string;
+  errorKey: 'userexists' | 'emailexists';
 };
 
 const usersKeys = {


### PR DESCRIPTION
### Description
at the call api of User and Account we detect the error type with test the error key to a string, the object is change the hard code test to test it with constant instead of strings.
### Issues
#79 
### How
add constent to to User and Account at 
`src/app/admin/users/users.constants.ts` for User
and 
`src/app/account/account.constants.ts` for Account