### PR TITLE
fix: Init dayjs with the current language on first load

### DIFF
--- a/src/config/dayjs.ts
+++ b/src/config/dayjs.ts
@@ -2,8 +2,5 @@ import dayjs from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import relativeTime from 'dayjs/plugin/relativeTime';
 
-import { DEFAULT_LANGUAGE_KEY } from '@/constants/i18n';
-
-dayjs.locale(DEFAULT_LANGUAGE_KEY);
 dayjs.extend(relativeTime);
 dayjs.extend(customParseFormat);

--- a/src/config/i18next.ts
+++ b/src/config/i18next.ts
@@ -6,6 +6,8 @@ import { AVAILABLE_LANGUAGES, DEFAULT_LANGUAGE_KEY } from '@/constants/i18n';
 import * as locales from '@/locales';
 import { isBrowser } from '@/utils/ssr';
 
+dayjs.locale(DEFAULT_LANGUAGE_KEY);
+
 i18n.use(initReactI18next).init({
   defaultNS: 'common',
   ns: Object.keys((locales as ExplicitAny)[DEFAULT_LANGUAGE_KEY]),


### PR DESCRIPTION
Before this PR, if the default language was changed, the default dayjs locale was still "en".