### PR TITLE
feat: add query-key-factory library + integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@formiz/core": "1.8.1",
     "@formiz/validations": "1.0.0",
     "@formkit/auto-animate": "1.0.0-beta.5",
-    "@lukemorales/query-key-factory": "0.6.1",
+    "@lukemorales/query-key-factory": "1.2.0",
     "@tanstack/react-query": "4.18.0",
     "@tanstack/react-query-devtools": "4.18.0",
     "axios": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@formiz/core": "1.8.1",
     "@formiz/validations": "1.0.0",
     "@formkit/auto-animate": "1.0.0-beta.5",
-    "@lukemorales/query-key-factory": "0.2.1",
+    "@lukemorales/query-key-factory": "0.6.1",
     "@tanstack/react-query": "4.18.0",
     "@tanstack/react-query-devtools": "4.18.0",
     "axios": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@formiz/core": "1.8.1",
     "@formiz/validations": "1.0.0",
     "@formkit/auto-animate": "1.0.0-beta.5",
+    "@lukemorales/query-key-factory": "0.2.1",
     "@tanstack/react-query": "4.18.0",
     "@tanstack/react-query-devtools": "4.18.0",
     "axios": "1.2.0",

--- a/src/spa/account/PageProfile.tsx
+++ b/src/spa/account/PageProfile.tsx
@@ -39,7 +39,7 @@ export const PageProfile = () => {
       toastSuccess({
         title: t('account:profile.feedbacks.updateSuccess.title'),
       });
-      queryClient.invalidateQueries(accountKeys.account());
+      queryClient.invalidateQueries(accountKeys.account);
     },
   });
 

--- a/src/spa/account/account.service.ts
+++ b/src/spa/account/account.service.ts
@@ -24,12 +24,12 @@ export const useAccount = (
     Account,
     AxiosError,
     Account,
-    AccountKeys['account']
+    AccountKeys['account']['queryKey']
   > = {}
 ) => {
   const { i18n } = useTranslation();
   const { data: account, ...rest } = useQuery(
-    accountKeys.account,
+    accountKeys.account.queryKey,
     (): Promise<Account> => Axios.get('/account'),
     {
       onSuccess: (data) => {

--- a/src/spa/account/account.service.ts
+++ b/src/spa/account/account.service.ts
@@ -1,3 +1,4 @@
+import { createQueryKeys } from '@lukemorales/query-key-factory';
 import {
   UseMutationOptions,
   UseQueryOptions,
@@ -10,22 +11,21 @@ import { useTranslation } from 'react-i18next';
 import { DEFAULT_LANGUAGE_KEY } from '@/constants/i18n';
 import { Account } from '@/spa/account/account.types';
 
-export const accountKeys = {
-  all: () => ['accountService'] as const,
-  account: () => [...accountKeys.all(), 'account'] as const,
-};
+export const accountKeys = createQueryKeys('accountService', {
+  account: null,
+});
 
 export const useAccount = (
   config: UseQueryOptions<
     Account,
     AxiosError,
     Account,
-    InferQueryKey<typeof accountKeys.account>
+    typeof accountKeys.account
   > = {}
 ) => {
   const { i18n } = useTranslation();
   const { data: account, ...rest } = useQuery(
-    accountKeys.account(),
+    accountKeys.account,
     (): Promise<Account> => Axios.get('/account'),
     {
       onSuccess: (data) => {

--- a/src/spa/account/account.service.ts
+++ b/src/spa/account/account.service.ts
@@ -1,4 +1,7 @@
-import { createQueryKeys } from '@lukemorales/query-key-factory';
+import {
+  createQueryKeys,
+  inferQueryKeys,
+} from '@lukemorales/query-key-factory';
 import {
   UseMutationOptions,
   UseQueryOptions,
@@ -14,13 +17,14 @@ import { Account } from '@/spa/account/account.types';
 export const accountKeys = createQueryKeys('accountService', {
   account: null,
 });
+type AccountKeys = inferQueryKeys<typeof accountKeys>;
 
 export const useAccount = (
   config: UseQueryOptions<
     Account,
     AxiosError,
     Account,
-    typeof accountKeys.account
+    AccountKeys['account']
   > = {}
 ) => {
   const { i18n } = useTranslation();

--- a/src/spa/admin/users/PageUserUpdate.tsx
+++ b/src/spa/admin/users/PageUserUpdate.tsx
@@ -38,7 +38,7 @@ export const PageUserUpdate = () => {
     isLoading: userIsLoading,
     isFetching: userIsFetching,
     isError: userIsError,
-  } = useUser(login, { refetchOnWindowFocus: false });
+  } = useUser(login, { refetchOnWindowFocus: false, enabled: !!login });
 
   const form = useForm({ subscribe: false });
 

--- a/src/spa/admin/users/users.service.ts
+++ b/src/spa/admin/users/users.service.ts
@@ -22,8 +22,8 @@ type UserMutateError = {
 const USERS_BASE_URL = '/admin/users';
 
 const usersKeys = createQueryKeys('usersService', {
-  users: (params: { page?: number; size?: number }) => params,
-  user: (params: { login?: string }) => params,
+  users: (params: { page?: number; size?: number }) => [params],
+  user: (params: { login?: string }) => [params],
 });
 type UsersKeys = inferQueryKeys<typeof usersKeys>;
 
@@ -33,11 +33,11 @@ export const useUserList = (
     UserList,
     AxiosError,
     UserList,
-    UsersKeys['users']
+    UsersKeys['users']['queryKey']
   > = {}
 ) => {
   const result = useQuery(
-    usersKeys.users({ page, size }),
+    usersKeys.users({ page, size }).queryKey,
     (): Promise<UserList> =>
       Axios.get(USERS_BASE_URL, { params: { page, size, sort: 'id,desc' } }),
     { keepPreviousData: true, ...config }
@@ -60,10 +60,15 @@ export const useUserList = (
 
 export const useUser = (
   userLogin?: string,
-  config: UseQueryOptions<User, AxiosError, User, UsersKeys['user']> = {}
+  config: UseQueryOptions<
+    User,
+    AxiosError,
+    User,
+    UsersKeys['user']['queryKey']
+  > = {}
 ) => {
   const result = useQuery(
-    usersKeys.user({ login: userLogin }),
+    usersKeys.user({ login: userLogin }).queryKey,
     (): Promise<User> => Axios.get(`${USERS_BASE_URL}/${userLogin}`),
     {
       enabled: !!userLogin,

--- a/src/spa/admin/users/users.service.ts
+++ b/src/spa/admin/users/users.service.ts
@@ -85,10 +85,10 @@ export const useUserUpdate = (
   return useMutation((payload) => Axios.put(USERS_BASE_URL, payload), {
     ...config,
     onSuccess: (data, payload, ...rest) => {
-      queryClient.cancelQueries(usersKeys.users.toScope());
+      queryClient.cancelQueries(usersKeys.users._def);
       queryClient
         .getQueryCache()
-        .findAll(usersKeys.users.toScope())
+        .findAll(usersKeys.users._def)
         .forEach(({ queryKey }) => {
           queryClient.setQueryData<UserList | undefined>(
             queryKey,
@@ -103,7 +103,7 @@ export const useUserUpdate = (
             }
           );
         });
-      queryClient.invalidateQueries(usersKeys.users.toScope());
+      queryClient.invalidateQueries(usersKeys.users._def);
       queryClient.invalidateQueries(usersKeys.user({ login: payload.login }));
       if (config.onSuccess) {
         config.onSuccess(data, payload, ...rest);
@@ -132,7 +132,7 @@ export const useUserCreate = (
     {
       ...config,
       onSuccess: (...args) => {
-        queryClient.invalidateQueries(usersKeys.users.toScope());
+        queryClient.invalidateQueries(usersKeys.users._def);
         config?.onSuccess?.(...args);
       },
     }
@@ -151,7 +151,7 @@ export const useUserRemove = (
     {
       ...config,
       onSuccess: (...args) => {
-        queryClient.invalidateQueries(usersKeys.users.toScope());
+        queryClient.invalidateQueries(usersKeys.users._def);
         config?.onSuccess?.(...args);
       },
     }

--- a/src/spa/admin/users/users.service.ts
+++ b/src/spa/admin/users/users.service.ts
@@ -1,3 +1,4 @@
+import { createQueryKeys } from '@lukemorales/query-key-factory';
 import {
   UseMutationOptions,
   UseQueryOptions,
@@ -18,11 +19,8 @@ type UserMutateError = {
 const USERS_BASE_URL = '/admin/users';
 
 const usersKeys = createQueryKeys('usersService', {
-  users: ({ page, size }: { page?: number; size?: number }) => ({
-    page,
-    size,
-  }),
-  user: ({ login }: { login?: string }) => ({ login }),
+  users: (params: { page?: number; size?: number }) => params,
+  user: (params: { login?: string }) => params,
 });
 
 export const useUserList = (

--- a/src/spa/admin/users/users.service.ts
+++ b/src/spa/admin/users/users.service.ts
@@ -1,4 +1,7 @@
-import { createQueryKeys } from '@lukemorales/query-key-factory';
+import {
+  createQueryKeys,
+  inferQueryKeys,
+} from '@lukemorales/query-key-factory';
 import {
   UseMutationOptions,
   UseQueryOptions,
@@ -22,6 +25,7 @@ const usersKeys = createQueryKeys('usersService', {
   users: (params: { page?: number; size?: number }) => params,
   user: (params: { login?: string }) => params,
 });
+type UsersKeys = inferQueryKeys<typeof usersKeys>;
 
 export const useUserList = (
   { page = 0, size = 10 } = {},
@@ -29,7 +33,7 @@ export const useUserList = (
     UserList,
     AxiosError,
     UserList,
-    InferQueryKey<typeof usersKeys.users>
+    UsersKeys['users']
   > = {}
 ) => {
   const result = useQuery(
@@ -56,12 +60,7 @@ export const useUserList = (
 
 export const useUser = (
   userLogin?: string,
-  config: UseQueryOptions<
-    User,
-    AxiosError,
-    User,
-    InferQueryKey<typeof usersKeys.user>
-  > = {}
+  config: UseQueryOptions<User, AxiosError, User, UsersKeys['user']> = {}
 ) => {
   const result = useQuery(
     usersKeys.user({ login: userLogin }),

--- a/src/spa/admin/users/users.service.ts
+++ b/src/spa/admin/users/users.service.ts
@@ -17,13 +17,13 @@ type UserMutateError = {
 
 const USERS_BASE_URL = '/admin/users';
 
-const usersKeys = {
-  all: () => ['usersService'] as const,
-  users: ({ page, size }: { page?: number; size?: number }) =>
-    [...usersKeys.all(), 'users', { page, size }] as const,
-  user: ({ login }: { login?: string }) =>
-    [...usersKeys.all(), 'user', { login }] as const,
-};
+const usersKeys = createQueryKeys('usersService', {
+  users: ({ page, size }: { page?: number; size?: number }) => ({
+    page,
+    size,
+  }),
+  user: ({ login }: { login?: string }) => ({ login }),
+});
 
 export const useUserList = (
   { page = 0, size = 10 } = {},
@@ -87,10 +87,10 @@ export const useUserUpdate = (
   return useMutation((payload) => Axios.put(USERS_BASE_URL, payload), {
     ...config,
     onSuccess: (data, payload, ...rest) => {
-      queryClient.cancelQueries([...usersKeys.all(), 'users']);
+      queryClient.cancelQueries(usersKeys.users.toScope());
       queryClient
         .getQueryCache()
-        .findAll([...usersKeys.all(), 'users'])
+        .findAll(usersKeys.users.toScope())
         .forEach(({ queryKey }) => {
           queryClient.setQueryData<UserList | undefined>(
             queryKey,
@@ -105,7 +105,7 @@ export const useUserUpdate = (
             }
           );
         });
-      queryClient.invalidateQueries([...usersKeys.all(), 'users']);
+      queryClient.invalidateQueries(usersKeys.users.toScope());
       queryClient.invalidateQueries(usersKeys.user({ login: payload.login }));
       if (config.onSuccess) {
         config.onSuccess(data, payload, ...rest);
@@ -134,7 +134,7 @@ export const useUserCreate = (
     {
       ...config,
       onSuccess: (...args) => {
-        queryClient.invalidateQueries([...usersKeys.all(), 'users']);
+        queryClient.invalidateQueries(usersKeys.users.toScope());
         config?.onSuccess?.(...args);
       },
     }
@@ -153,7 +153,7 @@ export const useUserRemove = (
     {
       ...config,
       onSuccess: (...args) => {
-        queryClient.invalidateQueries([...usersKeys.all(), 'users']);
+        queryClient.invalidateQueries(usersKeys.users.toScope());
         config?.onSuccess?.(...args);
       },
     }

--- a/src/types/utilities.d.ts
+++ b/src/types/utilities.d.ts
@@ -16,8 +16,3 @@ type ExplicitAny = any;
  * with the `as` props.
  */
 type Overwrite<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U;
-
-/**
- * Use this type to type react-query QueryKeys
- */
-type InferQueryKey<T extends (...args: any) => readonly any[]> = ReturnType<T>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2653,6 +2653,11 @@
   resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
   integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
+"@lukemorales/query-key-factory@0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@lukemorales/query-key-factory/-/query-key-factory-0.2.1.tgz#48cb13d737c66490886f55304ce976946663e65b"
+  integrity sha512-BmIamm4JooL6rlCF/Q7A1ZKxzUP23qGWHzlKskMA8n8dyEPWPVGjnMtxX3LugJu2YdAZeCmyCPFXZ8dvOBfH6g==
+
 "@mdx-js/mdx@^1.6.22":
   version "1.6.22"
   resolved "https://registry.yarnpkg.com/@mdx-js/mdx/-/mdx-1.6.22.tgz#8a723157bf90e78f17dc0f27995398e6c731f1ba"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2653,10 +2653,10 @@
   resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
   integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
-"@lukemorales/query-key-factory@0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@lukemorales/query-key-factory/-/query-key-factory-0.2.1.tgz#48cb13d737c66490886f55304ce976946663e65b"
-  integrity sha512-BmIamm4JooL6rlCF/Q7A1ZKxzUP23qGWHzlKskMA8n8dyEPWPVGjnMtxX3LugJu2YdAZeCmyCPFXZ8dvOBfH6g==
+"@lukemorales/query-key-factory@0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@lukemorales/query-key-factory/-/query-key-factory-0.6.1.tgz#19f9bae9f1b83554e52d9884b60f7049736c7406"
+  integrity sha512-VgqEQFSvihTSDDNdzWXnfogfz8IWURBdFRxXjUBiF3R0cK7WsAz8m3pFJZLWj4o0l2WiCN9vCAcj8cZPp9x0Jg==
 
 "@mdx-js/mdx@^1.6.22":
   version "1.6.22"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2653,10 +2653,10 @@
   resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
   integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
-"@lukemorales/query-key-factory@0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@lukemorales/query-key-factory/-/query-key-factory-0.6.1.tgz#19f9bae9f1b83554e52d9884b60f7049736c7406"
-  integrity sha512-VgqEQFSvihTSDDNdzWXnfogfz8IWURBdFRxXjUBiF3R0cK7WsAz8m3pFJZLWj4o0l2WiCN9vCAcj8cZPp9x0Jg==
+"@lukemorales/query-key-factory@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@lukemorales/query-key-factory/-/query-key-factory-1.2.0.tgz#ad4b3ded9ed6e5fd8f972c84840fb0d393f7d77e"
+  integrity sha512-ilUedLpJdpOCMKgxoncRkYEFF7C+K//IK/QWXHs0G6HjmZunT9XcrpWHNc5RjrBBqPhdxYNa7aUoEhjonwl4eQ==
 
 "@mdx-js/mdx@^1.6.22":
   version "1.6.22"


### PR DESCRIPTION
I integrate query-key-factory library to replace our custom query keys on services files.
I think it's more simple to write, to understand and to use.