### PR TITLE
Issue: add cypress test example for cypress formiz validation

### DIFF
--- a/src/components/FieldInput/Input.cy.tsx
+++ b/src/components/FieldInput/Input.cy.tsx
@@ -1,0 +1,33 @@
+import { Button } from '@chakra-ui/react';
+import { Formiz, useForm } from '@formiz/core';
+
+import { FieldInput } from '@/components/FieldInput';
+
+const WrapperComponent = ({ onSubmit }: any) => {
+  const form = useForm();
+
+  console.log({ isValid: form.isValid });
+
+  const handleSubmit = (values: any) => {
+    console.log('onSubmit', { values, form });
+    onSubmit(values);
+  };
+
+  return (
+    <Formiz autoForm onValidSubmit={handleSubmit} connect={form}>
+      <FieldInput name="input" label="My Input" required="Required" />
+      <Button type="submit">Submit</Button>
+    </Formiz>
+  );
+};
+
+describe('FieldInput', () => {
+  it('supports a "label" prop to set the aria-label', () => {
+    const handleValidSubmit = cy.spy().as('handleValidSubmit');
+
+    cy.mount(<WrapperComponent onSubmit={handleValidSubmit} />);
+
+    cy.get('button').click();
+    cy.get('@handleValidSubmit').should('not.have.been.called');
+  });
+});


### PR DESCRIPTION
This PR contains a cypress test that show a formiz issue with Cypress. The onValidSubmit is trigger even though the form is invalid

The isValid form prop looks to be updated too late, after the submit : 
![image](https://user-images.githubusercontent.com/48803115/195389567-49d0cb9a-e94f-4266-ae8e-bf05c09c54ee.png)
