### PR TITLE
style: remove explicit any in 18n config

### DIFF
--- a/src/config/i18next.ts
+++ b/src/config/i18next.ts
@@ -10,7 +10,7 @@ dayjs.locale(DEFAULT_LANGUAGE_KEY);
 
 i18n.use(initReactI18next).init({
   defaultNS: 'common',
-  ns: Object.keys((locales as ExplicitAny)[DEFAULT_LANGUAGE_KEY]),
+  ns: Object.keys(locales[DEFAULT_LANGUAGE_KEY]),
   resources: locales,
   lng: DEFAULT_LANGUAGE_KEY,
   fallbackLng: DEFAULT_LANGUAGE_KEY,

--- a/src/constants/i18n.ts
+++ b/src/constants/i18n.ts
@@ -1,5 +1,7 @@
+import * as locales from '@/locales';
+
 type Language = {
-  key: string;
+  key: keyof typeof locales;
   dir?: 'ltr' | 'rtl';
   fontScale?: number;
 };


### PR DESCRIPTION
We can remove the explicit any by writing an enum type from locale object 