### PR TITLE
feat: override Formiz useField and useForm types

### DIFF
--- a/src/components/FieldBooleanCheckbox/docs.stories.tsx
+++ b/src/components/FieldBooleanCheckbox/docs.stories.tsx
@@ -8,7 +8,7 @@ export default {
 };
 export const Default = () => {
   return (
-    <Formiz autoForm>
+    <Formiz autoForm onChange={console.log}>
       <Stack spacing={4}>
         <FieldBooleanCheckbox
           name="FieldBooleanCheckbox"

--- a/src/components/FieldBooleanCheckbox/index.tsx
+++ b/src/components/FieldBooleanCheckbox/index.tsx
@@ -5,7 +5,7 @@ import { FieldProps, useField } from '@formiz/core';
 
 import { FormGroup, FormGroupProps } from '@/components/FormGroup';
 
-export type FieldBooleanCheckboxProps = FieldProps &
+export type FieldBooleanCheckboxProps = FieldProps<boolean> &
   FormGroupProps & {
     optionLabel?: string;
     size?: 'sm' | 'md' | 'lg';
@@ -21,7 +21,7 @@ export const FieldBooleanCheckbox = (props: FieldBooleanCheckboxProps) => {
     setValue,
     value,
     otherProps,
-  } = useField({ debounce: 0, ...props });
+  } = useField({ debounce: 0, defaultValue: false, ...props });
   const { required } = props;
   const {
     children,
@@ -31,7 +31,7 @@ export const FieldBooleanCheckbox = (props: FieldBooleanCheckboxProps) => {
     size = 'md',
     isDisabled,
     ...rest
-  } = otherProps as Omit<FieldBooleanCheckboxProps, keyof FieldProps>;
+  } = otherProps;
   const [isTouched, setIsTouched] = useState(false);
   const showError = !isValid && (isTouched || isSubmitted);
 
@@ -55,7 +55,7 @@ export const FieldBooleanCheckbox = (props: FieldBooleanCheckboxProps) => {
       <Checkbox
         id={id}
         size={size}
-        value={value ?? false}
+        value={`${value}`}
         isDisabled={isDisabled}
         onChange={() => setValue(!value)}
       >

--- a/src/components/FieldCheckboxes/index.tsx
+++ b/src/components/FieldCheckboxes/index.tsx
@@ -53,8 +53,8 @@ type FieldCheckboxesState = {
   options: InternalOption[];
   registerOption: (option: InternalOption, isChecked: boolean) => void;
   unregisterOption: (option: InternalOption) => void;
-  values: Value[];
-  setValues: (values: Value[]) => void;
+  values: Value[] | null;
+  setValues: (values: Value[] | null) => void;
   toggleValue: (value: Value) => void;
   toggleGroups: (groups: string[]) => void;
   verifyIsValueChecked: (value: Value) => boolean;
@@ -72,7 +72,7 @@ const FieldCheckboxesContext = createContext<FieldCheckboxesContextProps>(
   {} as TODO
 );
 
-type FieldCheckboxesProps = FieldProps &
+type FieldCheckboxesProps = FieldProps<Array<Value>> &
   Omit<FormGroupProps, 'size'> &
   Pick<CheckboxProps, 'size' | 'colorScheme'> & {
     itemKey?: string;
@@ -102,7 +102,7 @@ export const FieldCheckboxes: React.FC<
     colorScheme,
     isDisabled,
     ...rest
-  } = otherProps as Omit<FieldCheckboxesProps, keyof FieldProps>;
+  } = otherProps;
 
   const valueRef = useRef(value);
   valueRef.current = value;
@@ -133,7 +133,7 @@ export const FieldCheckboxes: React.FC<
         isChecked: boolean
       ) => {
         set((state) => ({ options: [...state.options, optionToRegister] }));
-        setValue((prevValue: Value[]) =>
+        setValue((prevValue) =>
           isChecked ? [...(prevValue ?? []), optionToRegister.value] : prevValue
         );
       },
@@ -144,7 +144,7 @@ export const FieldCheckboxes: React.FC<
               !checkValuesEqual(option.value, optionToUnregister.value)
           ),
         }));
-        setValue((prevValue: Value[]) => {
+        setValue((prevValue) => {
           const newValue = (prevValue ?? []).filter((localValue) =>
             verifyValueIsInValues(
               get().options.map(({ value: optionValue }) => optionValue) ?? [],
@@ -160,7 +160,7 @@ export const FieldCheckboxes: React.FC<
           values,
         })),
       toggleValue: (valueToUpdate) => {
-        setValue((prevValue: Value[]) => {
+        setValue((prevValue) => {
           const previousValue = prevValue ?? [];
           const hasValue = verifyValueIsInValues(
             prevValue ?? [],
@@ -177,7 +177,7 @@ export const FieldCheckboxes: React.FC<
       toggleGroups: (groups: string[]) => {
         const [allValuesInGroups, allOtherValues] =
           splitValuesByGroupsFromOptions(get().options, groups);
-        setValue((previousValue: Value[]) => {
+        setValue((previousValue) => {
           const allOtherValuesChecked = allOtherValues.filter((otherValue) =>
             verifyValueIsInValues(previousValue ?? [], otherValue)
           );

--- a/src/components/FieldCurrency/index.tsx
+++ b/src/components/FieldCurrency/index.tsx
@@ -6,14 +6,13 @@ import { FieldProps, useField } from '@formiz/core';
 import { FormGroup, FormGroupProps } from '@/components/FormGroup';
 import { InputCurrency, InputCurrencyProps } from '@/components/InputCurrency';
 
-export type FieldCurrencyProps = Omit<FieldProps, 'value'> &
+export type FieldCurrencyProps = FieldProps<number> &
   Omit<FormGroupProps, 'placeholder'> &
   Pick<
     InputCurrencyProps,
     'currency' | 'locale' | 'decimals' | 'placeholder'
   > & {
     size?: 'sm' | 'md' | 'lg';
-    value?: number;
   };
 
 export const FieldCurrency = (props: FieldCurrencyProps) => {
@@ -39,7 +38,7 @@ export const FieldCurrency = (props: FieldCurrencyProps) => {
     locale,
     decimals,
     ...rest
-  } = otherProps as Omit<FieldCurrencyProps, keyof FieldProps>;
+  } = otherProps;
   const { required } = props;
   const [isTouched, setIsTouched] = useState(false);
   const showError = !isValid && ((isTouched && !isPristine) || isSubmitted);
@@ -63,8 +62,8 @@ export const FieldCurrency = (props: FieldCurrencyProps) => {
       <InputGroup size={size}>
         <InputCurrency
           id={id}
-          value={value ?? null}
-          onChange={setValue}
+          value={value ?? undefined}
+          onChange={(value) => setValue(value ?? null)}
           onFocus={() => setIsTouched(false)}
           onBlur={() => setIsTouched(true)}
           placeholder={placeholder}

--- a/src/components/FieldDayPicker/index.tsx
+++ b/src/components/FieldDayPicker/index.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { DayPicker } from '@/components/DayPicker';
 import { FormGroup, FormGroupProps } from '@/components/FormGroup';
 
-export type FieldDayPickerProps = FieldProps &
+export type FieldDayPickerProps = FieldProps<Date> &
   FormGroupProps & {
     invalidMessage?: string;
   };
@@ -29,10 +29,7 @@ export const FieldDayPicker = (props: FieldDayPickerProps) => {
     debounce: 0,
     ...fieldProps,
   });
-  const { children, label, placeholder, helper, ...rest } = otherProps as Omit<
-    FieldDayPickerProps,
-    keyof FieldProps
-  >;
+  const { children, label, placeholder, helper, ...rest } = otherProps;
   const { required } = props;
   const [isTouched, setIsTouched] = useState(false);
   const showError = !isValid && ((isTouched && !isPristine) || isSubmitted);
@@ -55,7 +52,7 @@ export const FieldDayPicker = (props: FieldDayPickerProps) => {
     date: Date | null | undefined,
     isValidDate: boolean
   ) => {
-    setValue(date);
+    setValue(date ?? null);
     if (!isValidDate) {
       invalidateFields({
         [props.name]:

--- a/src/components/FieldHidden/index.tsx
+++ b/src/components/FieldHidden/index.tsx
@@ -4,7 +4,7 @@ import { FieldProps, useField } from '@formiz/core';
 
 import { FormGroup, FormGroupProps } from '@/components/FormGroup';
 
-type FieldHiddenProps = FieldProps & FormGroupProps;
+type FieldHiddenProps = FieldProps<unknown> & FormGroupProps;
 
 export const FieldHidden: React.FC<
   React.PropsWithChildren<FieldHiddenProps>
@@ -13,7 +13,7 @@ export const FieldHidden: React.FC<
     debounce: 0,
     ...props,
   });
-  const { ...rest } = otherProps as Omit<FieldHiddenProps, keyof FieldProps>;
+  const { ...rest } = otherProps;
   const showError = !isValid && isSubmitted;
   const formGroupProps = {
     errorMessage,

--- a/src/components/FieldInput/index.tsx
+++ b/src/components/FieldInput/index.tsx
@@ -14,7 +14,7 @@ import { RiEyeCloseLine, RiEyeLine } from 'react-icons/ri';
 
 import { FormGroup, FormGroupProps } from '@/components/FormGroup';
 
-export type FieldInputProps = FieldProps &
+export type FieldInputProps = FieldProps<string> &
   Omit<FormGroupProps, 'placeholder'> &
   Pick<InputProps, 'type' | 'placeholder'> & {
     size?: 'sm' | 'md' | 'lg';
@@ -43,7 +43,7 @@ export const FieldInput = (props: FieldInputProps) => {
     size = 'md',
     autoFocus,
     ...rest
-  } = otherProps as Omit<FieldInputProps, keyof FieldProps>;
+  } = otherProps;
   const { required } = props;
   const [isTouched, setIsTouched] = useState(false);
   const [showPassword, setShowPassword] = useState(false);

--- a/src/components/FieldMultiSelect/docs.stories.tsx
+++ b/src/components/FieldMultiSelect/docs.stories.tsx
@@ -45,7 +45,7 @@ export const DefaultValue = () => {
           name="mySelect"
           label="Label"
           helper="Helper"
-          defaultValue={options[0]?.value}
+          defaultValue={options[0]?.value ? [options[0]?.value] : undefined}
           options={options}
           required="Required"
         />

--- a/src/components/FieldMultiSelect/docs.stories.tsx
+++ b/src/components/FieldMultiSelect/docs.stories.tsx
@@ -7,7 +7,7 @@ export default {
   title: 'Fields/FieldMultiSelect',
 };
 
-const options = [
+const options: Array<{ label: string; value: string }> = [
   { label: 'One', value: 'One' },
   { label: 'Two', value: 'Two' },
   { label: 'Three', value: 'Three' },

--- a/src/components/FieldMultiSelect/index.tsx
+++ b/src/components/FieldMultiSelect/index.tsx
@@ -1,24 +1,32 @@
-import { useEffect, useState } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 
 import { FieldProps, useField } from '@formiz/core';
 import { useTranslation } from 'react-i18next';
-import { GroupBase } from 'react-select';
+import { GroupBase, MultiValue } from 'react-select';
 
-import { FieldSelectProps } from '@/components/FieldSelect';
-import { FormGroup } from '@/components/FormGroup';
-import { Select } from '@/components/Select';
+import { FormGroup, FormGroupProps } from '@/components/FormGroup';
+import { Select, SelectProps } from '@/components/Select';
+
+type MinimumOption = { value: unknown; label: ReactNode };
 
 export type FieldMultiSelectProps<
-  Option,
+  Option extends MinimumOption,
   IsMulti extends boolean = true,
   Group extends GroupBase<Option> = GroupBase<Option>
-> = FieldSelectProps<Option, IsMulti, Group> & {
+> = FieldProps<MultiValue<Option['value']>> & {
   isNotClearable?: boolean;
   noOptionsMessage?: string;
-};
+} & FormGroupProps & {
+    placeholder?: string;
+    size?: 'sm' | 'md' | 'lg';
+    options?: Option[];
+    isClearable?: boolean;
+    isSearchable?: boolean;
+    selectProps?: SelectProps<Option, IsMulti, Group>;
+  };
 
 export const FieldMultiSelect = <
-  Option,
+  Option extends MinimumOption,
   IsMulti extends boolean = true,
   Group extends GroupBase<Option> = GroupBase<Option>
 >(
@@ -49,10 +57,7 @@ export const FieldMultiSelect = <
     size,
     selectProps = {},
     ...rest
-  } = otherProps as Omit<
-    FieldMultiSelectProps<Option, IsMulti, Group>,
-    keyof FieldProps
-  >;
+  } = otherProps;
   const [isTouched, setIsTouched] = useState(false);
   const showError = !isValid && ((isTouched && !isPristine) || isSubmitted);
 
@@ -77,16 +82,14 @@ export const FieldMultiSelect = <
       setValue(null);
       return;
     }
-    setValue(optionsSelected?.map((option: TODO) => option?.value));
+    setValue(optionsSelected?.map((option) => option?.value));
   };
 
   return (
     <FormGroup {...formGroupProps}>
       <Select
         id={id}
-        value={
-          options?.filter((option: TODO) => value?.includes(option.value)) || []
-        }
+        value={options?.filter((option) => value?.includes(option.value)) || []}
         onFocus={() => setIsTouched(false)}
         onBlur={() => setIsTouched(true)}
         placeholder={placeholder}

--- a/src/components/FieldMultiSelect/index.tsx
+++ b/src/components/FieldMultiSelect/index.tsx
@@ -7,10 +7,10 @@ import { GroupBase, MultiValue } from 'react-select';
 import { FormGroup, FormGroupProps } from '@/components/FormGroup';
 import { Select, SelectProps } from '@/components/Select';
 
-type MinimumOption = { value: unknown; label: ReactNode };
+type BaseOption = { value: unknown; label: ReactNode };
 
 export type FieldMultiSelectProps<
-  Option extends MinimumOption,
+  Option extends BaseOption,
   IsMulti extends boolean = true,
   Group extends GroupBase<Option> = GroupBase<Option>
 > = FieldProps<MultiValue<Option['value']>> & {
@@ -26,7 +26,7 @@ export type FieldMultiSelectProps<
   };
 
 export const FieldMultiSelect = <
-  Option extends MinimumOption,
+  Option extends BaseOption,
   IsMulti extends boolean = true,
   Group extends GroupBase<Option> = GroupBase<Option>
 >(

--- a/src/components/FieldRadios/index.tsx
+++ b/src/components/FieldRadios/index.tsx
@@ -10,7 +10,7 @@ type Option = {
   label?: ReactNode;
 };
 
-export type FieldRadiosProps = FieldProps &
+export type FieldRadiosProps = FieldProps<Option['value']> &
   FormGroupProps & {
     size?: 'sm' | 'md' | 'lg';
     options?: Option[];
@@ -35,7 +35,7 @@ export const FieldRadios = (props: FieldRadiosProps) => {
     helper,
     size = 'md',
     ...rest
-  } = otherProps as Omit<FieldRadiosProps, keyof FieldProps>;
+  } = otherProps;
   const [isTouched, setIsTouched] = useState(false);
   const showError = !isValid && (isTouched || isSubmitted);
 
@@ -55,7 +55,12 @@ export const FieldRadios = (props: FieldRadiosProps) => {
 
   return (
     <FormGroup {...formGroupProps}>
-      <RadioGroup size={size} id={id} value={value || []} onChange={setValue}>
+      <RadioGroup
+        size={size}
+        id={id}
+        value={value ?? undefined}
+        onChange={setValue}
+      >
         <Wrap spacing="4" overflow="visible">
           {options.map((option) => (
             <WrapItem key={option.value}>

--- a/src/components/FieldSelect/index.tsx
+++ b/src/components/FieldSelect/index.tsx
@@ -6,10 +6,10 @@ import { GroupBase, SingleValue } from 'react-select';
 import { FormGroup, FormGroupProps } from '@/components/FormGroup';
 import { Select, SelectProps } from '@/components/Select';
 
-type MinimumOption = { value: unknown; label: ReactNode };
+type BaseOption = { value: unknown; label: ReactNode };
 
 export type FieldSelectProps<
-  Option extends MinimumOption,
+  Option extends BaseOption,
   IsMulti extends boolean = false,
   Group extends GroupBase<Option> = GroupBase<Option>
 > = FieldProps<SingleValue<Option['value']>> &
@@ -23,7 +23,7 @@ export type FieldSelectProps<
   };
 
 export const FieldSelect = <
-  Option extends MinimumOption,
+  Option extends BaseOption,
   IsMulti extends boolean = false,
   Group extends GroupBase<Option> = GroupBase<Option>
 >(

--- a/src/components/FieldSelect/index.tsx
+++ b/src/components/FieldSelect/index.tsx
@@ -1,16 +1,18 @@
-import React, { useEffect, useState } from 'react';
+import React, { ReactNode, useEffect, useState } from 'react';
 
 import { FieldProps, useField } from '@formiz/core';
-import { GroupBase } from 'react-select';
+import { GroupBase, SingleValue } from 'react-select';
 
 import { FormGroup, FormGroupProps } from '@/components/FormGroup';
 import { Select, SelectProps } from '@/components/Select';
 
+type MinimumOption = { value: unknown; label: ReactNode };
+
 export type FieldSelectProps<
-  Option,
+  Option extends MinimumOption,
   IsMulti extends boolean = false,
   Group extends GroupBase<Option> = GroupBase<Option>
-> = FieldProps &
+> = FieldProps<SingleValue<Option['value']>> &
   FormGroupProps & {
     placeholder?: string;
     size?: 'sm' | 'md' | 'lg';
@@ -21,7 +23,7 @@ export type FieldSelectProps<
   };
 
 export const FieldSelect = <
-  Option,
+  Option extends MinimumOption,
   IsMulti extends boolean = false,
   Group extends GroupBase<Option> = GroupBase<Option>
 >(
@@ -51,10 +53,7 @@ export const FieldSelect = <
     size = 'md',
     selectProps,
     ...rest
-  } = otherProps as Omit<
-    FieldSelectProps<Option, IsMulti, Group>,
-    keyof FieldProps
-  >;
+  } = otherProps;
   const [isTouched, setIsTouched] = useState(false);
   const showError = !isValid && ((isTouched && !isPristine) || isSubmitted);
 
@@ -73,19 +72,19 @@ export const FieldSelect = <
     ...rest,
   };
 
+  const handleChange = (optionSelected: Option) => {
+    setValue(optionSelected ? optionSelected.value : null);
+  };
+
   return (
     <FormGroup {...formGroupProps}>
       <Select
         id={id}
-        value={
-          options?.find((option: TODO) => option.value === value) ?? undefined
-        }
+        value={options?.find((option) => option.value === value) ?? undefined}
         onFocus={() => setIsTouched(false)}
         onBlur={() => setIsTouched(true)}
         placeholder={placeholder || 'Select...'}
-        onChange={(fieldValue: TODO) =>
-          setValue(fieldValue ? fieldValue.value : null)
-        }
+        onChange={handleChange as TODO}
         size={size}
         options={options}
         isDisabled={isDisabled}

--- a/src/components/FieldTextarea/index.tsx
+++ b/src/components/FieldTextarea/index.tsx
@@ -5,7 +5,7 @@ import { FieldProps, useField } from '@formiz/core';
 
 import { FormGroup, FormGroupProps } from '@/components/FormGroup';
 
-export type FieldTextareaProps = FieldProps &
+export type FieldTextareaProps = FieldProps<string> &
   FormGroupProps & {
     textareaProps?: Omit<
       TextareaProps,
@@ -34,7 +34,7 @@ export const FieldTextarea = (props: FieldTextareaProps) => {
   } = useField(props);
 
   const { helper, label, placeholder, textareaProps, autoFocus, ...rest } =
-    otherProps as Omit<FieldTextareaProps, keyof FieldProps>;
+    otherProps;
 
   const { required } = props;
   const [isTouched, setIsTouched] = useState(false);

--- a/src/spa/account/PageRegister.tsx
+++ b/src/spa/account/PageRegister.tsx
@@ -140,7 +140,9 @@ export const PageRegister = () => {
                   label: t(`common:languages.${key}`),
                   value: key,
                 }))}
-                defaultValue={i18n.language}
+                defaultValue={
+                  i18n.language as typeof AVAILABLE_LANGUAGES[number]['key']
+                }
               />
               <FieldInput
                 name="login"

--- a/src/types/formiz-core/index.d.ts
+++ b/src/types/formiz-core/index.d.ts
@@ -1,0 +1,46 @@
+declare module '@formiz/core' {
+  export * from '@formiz/core/dist';
+
+  import {
+    UseFieldProps,
+    UseFieldValues,
+  } from '@formiz/core/dist/types/field.types';
+
+  // Override FieldProps type with generic param for define value type
+  export declare type FieldProps<Value = ExplicitAny> = Omit<
+    UseFieldProps,
+    'defaultValue' | 'onChange' | 'formatValue'
+  > & {
+    defaultValue?: Value;
+    onChange?: (value: Value, rawValue?: Value) => void;
+    formatValue?: (value: Value) => unknown;
+  };
+
+  // Override useField type for value and otherProps type inferred by props
+  export declare const useField: <
+    Props extends FieldProps = FieldProps,
+    Value = Required<Props>['defaultValue'] | null
+  >(
+    props: Props
+  ) => Omit<UseFieldValues, 'otherProps' | 'value' | 'setValue'> & {
+    otherProps: Omit<Props, keyof FieldProps>;
+    value: Value;
+    setValue(value: Value | ((prevValue: Value) => Value)): void;
+  };
+
+  import {
+    FormValues,
+    UseFormProps,
+    UseFormValues,
+  } from '@formiz/core/dist/types/form.types';
+
+  // Override Form type with generic param for values type
+  export declare type Form<T = FormValues> = Omit<UseFormValues, 'values'> & {
+    values: T;
+  };
+
+  // Override useForm type with generic param for type returned form
+  export declare const useForm: <T = FormValues>({
+    subscribe,
+  }?: UseFormProps) => Form<T>;
+}

--- a/src/types/formiz-core/index.d.ts
+++ b/src/types/formiz-core/index.d.ts
@@ -25,7 +25,7 @@ declare module '@formiz/core' {
   ) => Omit<UseFieldValues, 'otherProps' | 'value' | 'setValue'> & {
     otherProps: Omit<Props, keyof FieldProps>;
     value: Value;
-    setValue(value: Value | ((prevValue: Value) => Value)): void;
+    setValue: React.Dispatch<React.SetStateAction<Value>>;
   };
 
   import {

--- a/src/types/formiz-core/index.d.ts
+++ b/src/types/formiz-core/index.d.ts
@@ -6,7 +6,7 @@ declare module '@formiz/core' {
     UseFieldValues,
   } from '@formiz/core/dist/types/field.types';
 
-  // Override FieldProps type with generic param for define value type
+  // Override FieldProps type with generic param to define value type
   export declare type FieldProps<Value = ExplicitAny> = Omit<
     UseFieldProps,
     'defaultValue' | 'onChange' | 'formatValue'


### PR DESCRIPTION
This PR add Formiz useField and useForm hooks types override. 
* `useForm` : you can now pass a generic type param, that's going to type form values with indicated type
```ts
type FormValues = { email: string, password: string}
const form = useForm<FormValues>
typeof form.values === FormValues
```
* `useField` : two things :
  1. FieldProps now have a generic type param that will define field value type `FieldProps<string>`, passing props with type that extends `FieldProps<T>`, your field value type will be infer with T
  2. otherProps will now be inferred by useField props (if you have additional props, they will be contained in otherProps)
```ts
type FieldInputProps = FieldProps<string> & { oneOtherProp: string }
const { value, otherProps } = useField(props) // with props type is FieldInputProps
typeof value === string
typeof otherProps === { oneOtherProp: string }
```