### PR TITLE
feat: add type safety to i18n

### DIFF
--- a/src/components/ActionsButton/index.tsx
+++ b/src/components/ActionsButton/index.tsx
@@ -10,7 +10,7 @@ export type ActionsButtonProps = Omit<IconButtonProps, 'aria-label'> & {
 
 export const ActionsButton: FC<React.PropsWithChildren<ActionsButtonProps>> =
   forwardRef(({ label, ...rest }, ref) => {
-    const { t } = useTranslation();
+    const { t } = useTranslation(['components']);
     return (
       <IconButton
         ref={ref}

--- a/src/components/ConfirmMenuItem/index.tsx
+++ b/src/components/ConfirmMenuItem/index.tsx
@@ -123,7 +123,7 @@ export const ConfirmMenuItem = forwardRef<ConfirmMenuItemProps, 'button'>(
     },
     ref
   ) => {
-    const { t } = useTranslation();
+    const { t } = useTranslation(['components']);
 
     const [isConfirmActive, setIsConfirmActive] = useState(false);
     const timeoutRef = useRef<ReturnType<typeof setTimeout>>();

--- a/src/components/ConfirmModal/index.tsx
+++ b/src/components/ConfirmModal/index.tsx
@@ -39,7 +39,7 @@ export const ConfirmModal: React.FC<
   cancelText,
   ...rest
 }) => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['common', 'components']);
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   const displayHeading =

--- a/src/components/ConfirmPopover/index.tsx
+++ b/src/components/ConfirmPopover/index.tsx
@@ -41,7 +41,7 @@ export const ConfirmPopover: React.FC<
   cancelText,
   ...rest
 }) => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['common', 'components']);
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   const displayHeading =

--- a/src/components/DateAgo/index.tsx
+++ b/src/components/DateAgo/index.tsx
@@ -23,7 +23,7 @@ export type DateAgoProps = Omit<TooltipProps, 'children'> & {
 
 export const DateAgo: FC<React.PropsWithChildren<DateAgoProps>> = forwardRef(
   function DateAgo({ date = new Date(), format, ...rest }, ref) {
-    const { t } = useTranslation();
+    const { t } = useTranslation(['components']);
     const [, setForceUpdate] = useState(0);
     const dayjsDate = dayjs(date);
     const dateFormatted = dayjsDate.format();

--- a/src/components/ErrorBoundary/index.tsx
+++ b/src/components/ErrorBoundary/index.tsx
@@ -23,7 +23,7 @@ import { useTranslation } from 'react-i18next';
 
 const ErrorFallback = ({ error }: FallbackProps) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const { t } = useTranslation();
+  const { t } = useTranslation(['components']);
   return (
     <Box p="4" m="auto">
       <Alert status="error" borderRadius="md">

--- a/src/components/ErrorPage/index.tsx
+++ b/src/components/ErrorPage/index.tsx
@@ -11,7 +11,7 @@ import { Illustration404 } from './Illustration404';
 import { IllustrationDefault } from './IllustrationDefault';
 
 const SupportedErrors: Record<
-  'default' | number,
+  'default' | 403 | 404,
   { illustration?: ReactElement }
 > = {
   default: { illustration: <IllustrationDefault /> },
@@ -20,11 +20,10 @@ const SupportedErrors: Record<
 };
 
 export const ErrorPage = ({ errorCode }: { errorCode?: number }) => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['components']);
   const errorType =
-    errorCode &&
-    Object.keys(SupportedErrors).some((c) => c === String(errorCode))
-      ? errorCode
+    errorCode && errorCode in SupportedErrors
+      ? (errorCode as keyof typeof SupportedErrors)
       : 'default';
   const illustration =
     SupportedErrors[errorType].illustration ??

--- a/src/components/FieldDayPicker/index.tsx
+++ b/src/components/FieldDayPicker/index.tsx
@@ -12,7 +12,7 @@ export type FieldDayPickerProps = FieldProps &
   };
 
 export const FieldDayPicker = (props: FieldDayPickerProps) => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['components']);
   const { invalidMessage, ...fieldProps } = props;
   const { invalidateFields } = useForm({ subscribe: false });
   const {

--- a/src/components/FieldMultiSelect/index.tsx
+++ b/src/components/FieldMultiSelect/index.tsx
@@ -60,7 +60,7 @@ export const FieldMultiSelect = <
     setIsTouched(false);
   }, [resetKey]);
 
-  const { t } = useTranslation();
+  const { t } = useTranslation(['components']);
 
   const formGroupProps = {
     errorMessage,

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -76,7 +76,7 @@ export const PaginationButtonFirstPage: FC<
   React.PropsWithChildren<Omit<IconButtonProps, 'aria-label'>>
 > = ({ ...rest }) => {
   const { rtlValue } = useRtl();
-  const { t } = useTranslation();
+  const { t } = useTranslation(['components']);
   const { setPage, firstPage, isFirstPage } = useContext(PaginationContext);
   return (
     <IconButton
@@ -96,7 +96,7 @@ export const PaginationButtonPrevPage: FC<
   React.PropsWithChildren<Omit<IconButtonProps, 'aria-label'>>
 > = ({ ...rest }) => {
   const { rtlValue } = useRtl();
-  const { t } = useTranslation();
+  const { t } = useTranslation(['components']);
   const { setPage, page, isFirstPage } = useContext(PaginationContext);
   return (
     <IconButton
@@ -116,7 +116,7 @@ export const PaginationButtonLastPage: FC<
   React.PropsWithChildren<Omit<IconButtonProps, 'aria-label'>>
 > = ({ ...rest }) => {
   const { rtlValue } = useRtl();
-  const { t } = useTranslation();
+  const { t } = useTranslation(['components']);
   const { setPage, lastPage, isLastPage } = useContext(PaginationContext);
   return (
     <IconButton
@@ -136,7 +136,7 @@ export const PaginationButtonNextPage: FC<
   React.PropsWithChildren<Omit<IconButtonProps, 'aria-label'>>
 > = ({ ...rest }) => {
   const { rtlValue } = useRtl();
-  const { t } = useTranslation();
+  const { t } = useTranslation(['components']);
   const { setPage, page, isLastPage } = useContext(PaginationContext);
   return (
     <IconButton
@@ -153,7 +153,7 @@ export const PaginationButtonNextPage: FC<
 };
 
 export const PaginationInfo = ({ ...rest }) => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['components']);
   const { firstItemOnPage, lastItemOnPage, totalItems, isLoadingPage } =
     useContext(PaginationContext);
   const translationProps = {

--- a/src/components/SearchInput/index.tsx
+++ b/src/components/SearchInput/index.tsx
@@ -37,7 +37,7 @@ export const SearchInput = forwardRef<SearchInputProps, 'input'>(
     },
     ref
   ) => {
-    const { t } = useTranslation();
+    const { t } = useTranslation(['components']);
 
     const [externalValue, setExternalValue] = useControllableState({
       value,

--- a/src/components/Sort/index.tsx
+++ b/src/components/Sort/index.tsx
@@ -47,7 +47,7 @@ export const Sort: FC<React.PropsWithChildren<SortProps>> = ({
   descIcon = <IconSortDesc />,
   ...rest
 }) => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['components']);
 
   const { by, order } = sort;
 

--- a/src/config/i18next.ts
+++ b/src/config/i18next.ts
@@ -2,14 +2,18 @@ import dayjs from 'dayjs';
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 
-import { AVAILABLE_LANGUAGES, DEFAULT_LANGUAGE_KEY } from '@/constants/i18n';
-import * as locales from '@/locales';
+import {
+  AVAILABLE_LANGUAGES,
+  DEFAULT_LANGUAGE_KEY,
+  DEFAULT_NAMESPACE,
+} from '@/constants/i18n';
+import locales from '@/locales';
 import { isBrowser } from '@/utils/ssr';
 
 dayjs.locale(DEFAULT_LANGUAGE_KEY);
 
 i18n.use(initReactI18next).init({
-  defaultNS: 'common',
+  defaultNS: DEFAULT_NAMESPACE,
   ns: Object.keys(locales[DEFAULT_LANGUAGE_KEY]),
   resources: locales,
   lng: DEFAULT_LANGUAGE_KEY,

--- a/src/constants/i18n.ts
+++ b/src/constants/i18n.ts
@@ -1,10 +1,12 @@
-import * as locales from '@/locales';
+import locales from '@/locales';
 
-type Language = {
+export type Language = {
   key: keyof typeof locales;
   dir?: 'ltr' | 'rtl';
   fontScale?: number;
 };
+
+export const DEFAULT_NAMESPACE = 'common';
 
 export const DEFAULT_LANGUAGE_KEY: Language['key'] = 'en';
 

--- a/src/locales/ar/index.ts
+++ b/src/locales/ar/index.ts
@@ -1,8 +1,19 @@
-export { default as account } from './account.json';
-export { default as admin } from './admin.json';
-export { default as auth } from './auth.json';
-export { default as common } from './common.json';
-export { default as components } from './components.json';
-export { default as dashboard } from './dashboard.json';
-export { default as layout } from './layout.json';
-export { default as users } from './users.json';
+import account from './account.json';
+import admin from './admin.json';
+import auth from './auth.json';
+import common from './common.json';
+import components from './components.json';
+import dashboard from './dashboard.json';
+import layout from './layout.json';
+import users from './users.json';
+
+export default {
+  account,
+  admin,
+  auth,
+  common,
+  components,
+  dashboard,
+  layout,
+  users,
+} as const;

--- a/src/locales/en/index.ts
+++ b/src/locales/en/index.ts
@@ -1,8 +1,19 @@
-export { default as account } from './account.json';
-export { default as admin } from './admin.json';
-export { default as auth } from './auth.json';
-export { default as common } from './common.json';
-export { default as components } from './components.json';
-export { default as dashboard } from './dashboard.json';
-export { default as layout } from './layout.json';
-export { default as users } from './users.json';
+import account from './account.json';
+import admin from './admin.json';
+import auth from './auth.json';
+import common from './common.json';
+import components from './components.json';
+import dashboard from './dashboard.json';
+import layout from './layout.json';
+import users from './users.json';
+
+export default {
+  account,
+  admin,
+  auth,
+  common,
+  components,
+  dashboard,
+  layout,
+  users,
+} as const;

--- a/src/locales/fr/index.ts
+++ b/src/locales/fr/index.ts
@@ -1,8 +1,19 @@
-export { default as account } from './account.json';
-export { default as admin } from './admin.json';
-export { default as auth } from './auth.json';
-export { default as common } from './common.json';
-export { default as components } from './components.json';
-export { default as dashboard } from './dashboard.json';
-export { default as layout } from './layout.json';
-export { default as users } from './users.json';
+import account from './account.json';
+import admin from './admin.json';
+import auth from './auth.json';
+import common from './common.json';
+import components from './components.json';
+import dashboard from './dashboard.json';
+import layout from './layout.json';
+import users from './users.json';
+
+export default {
+  account,
+  admin,
+  auth,
+  common,
+  components,
+  dashboard,
+  layout,
+  users,
+} as const;

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -3,7 +3,9 @@ import 'dayjs/locale/en';
 import 'dayjs/locale/fr';
 import 'dayjs/locale/sw';
 
-export * as en from '@/locales/en';
-export * as fr from '@/locales/fr';
-export * as ar from '@/locales/ar';
-export * as sw from '@/locales/sw';
+import ar from '@/locales/ar';
+import en from '@/locales/en';
+import fr from '@/locales/fr';
+import sw from '@/locales/sw';
+
+export default { en, fr, ar, sw } as const;

--- a/src/locales/sw/index.ts
+++ b/src/locales/sw/index.ts
@@ -1,9 +1,19 @@
-export { default as account } from './account.json';
-export { default as admin } from './admin.json';
-export { default as auth } from './auth.json';
-export { default as common } from './common.json';
-export { default as components } from './components.json';
-export { default as dashboard } from './dashboard.json';
-export { default as errors } from './errors.json';
-export { default as layout } from './layout.json';
-export { default as users } from './users.json';
+import account from './account.json';
+import admin from './admin.json';
+import auth from './auth.json';
+import common from './common.json';
+import components from './components.json';
+import dashboard from './dashboard.json';
+import layout from './layout.json';
+import users from './users.json';
+
+export default {
+  account,
+  admin,
+  auth,
+  common,
+  components,
+  dashboard,
+  layout,
+  users,
+} as const;

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { ErrorPage } from '@/components/ErrorPage';
 
 const Page404 = () => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['components']);
   return (
     <>
       <Head>

--- a/src/pages/500.tsx
+++ b/src/pages/500.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { ErrorPage } from '@/components/ErrorPage';
 
 const Page500 = () => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['components']);
   return (
     <>
       <Head>

--- a/src/spa/account/AccountNav.tsx
+++ b/src/spa/account/AccountNav.tsx
@@ -7,7 +7,7 @@ import { Link, useLocation } from 'react-router-dom';
 import { Nav, NavGroup, NavItem } from '@/components/Nav';
 
 export const AccountNav = () => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['account']);
   const { pathname } = useLocation();
   const isActive = (to: string) => pathname.startsWith(to);
   return (

--- a/src/spa/account/PageActivate.tsx
+++ b/src/spa/account/PageActivate.tsx
@@ -7,7 +7,7 @@ import { useSearchParams } from 'react-router-dom';
 import { useActivateAccount } from '@/spa/account/account.service';
 
 export const PageActivate = () => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['account']);
   const {
     mutate: activateAccount,
     isError,

--- a/src/spa/account/PagePassword.tsx
+++ b/src/spa/account/PagePassword.tsx
@@ -12,7 +12,7 @@ import { useUpdatePassword } from '@/spa/account/account.service';
 import { Page, PageContent } from '@/spa/layout';
 
 export const PagePassword = () => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['account']);
   const changePasswordForm = useForm();
 
   const toastSuccess = useToastSuccess();

--- a/src/spa/account/PageProfile.tsx
+++ b/src/spa/account/PageProfile.tsx
@@ -19,7 +19,7 @@ import {
 import { Page, PageContent } from '@/spa/layout';
 
 export const PageProfile = () => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['common', 'account']);
   const { account } = useAccount();
   const generalInformationForm = useForm();
   const queryClient = useQueryClient();
@@ -102,7 +102,7 @@ export const PageProfile = () => {
                   name="langKey"
                   label={t('account:data.language.label')}
                   options={AVAILABLE_LANGUAGES.map(({ key }) => ({
-                    label: t(`languages.${key}`),
+                    label: t(`common:languages.${key}`),
                     value: key,
                   }))}
                 />

--- a/src/spa/account/PageRegister.tsx
+++ b/src/spa/account/PageRegister.tsx
@@ -30,7 +30,7 @@ import { AVAILABLE_LANGUAGES } from '@/constants/i18n';
 import { useCreateAccount } from '@/spa/account/account.service';
 
 export const PageRegister = () => {
-  const { t, i18n } = useTranslation();
+  const { t, i18n } = useTranslation(['common', 'account']);
   const form = useForm({
     subscribe: { form: true, fields: ['langKey'] },
   });
@@ -137,7 +137,7 @@ export const PageRegister = () => {
                 name="langKey"
                 label={t('account:data.language.label')}
                 options={AVAILABLE_LANGUAGES.map(({ key }) => ({
-                  label: t(`languages.${key}`),
+                  label: t(`common:languages.${key}`),
                   value: key,
                 }))}
                 defaultValue={i18n.language}

--- a/src/spa/account/PageResetPasswordConfirm.tsx
+++ b/src/spa/account/PageResetPasswordConfirm.tsx
@@ -12,7 +12,7 @@ import { useToastError, useToastSuccess } from '@/components/Toast';
 import { useResetPasswordFinish } from '@/spa/account/account.service';
 
 export const PageResetPasswordConfirm = () => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['account']);
 
   const [searchParams] = useSearchParams();
 

--- a/src/spa/account/PageResetPasswordRequest.tsx
+++ b/src/spa/account/PageResetPasswordRequest.tsx
@@ -25,7 +25,7 @@ import { useResetPasswordInit } from '@/spa/account/account.service';
 
 export const PageResetPasswordRequest = () => {
   const { rtlValue } = useRtl();
-  const { t } = useTranslation();
+  const { t } = useTranslation(['account']);
 
   const resetPasswordInitForm = useForm();
 

--- a/src/spa/admin/AdminNav.tsx
+++ b/src/spa/admin/AdminNav.tsx
@@ -8,7 +8,7 @@ import { Link, useLocation } from 'react-router-dom';
 import { Nav, NavGroup, NavItem } from '@/components/Nav';
 
 export const AdminNav = () => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['admin']);
   const { pathname } = useLocation();
   const isActive = (to: string) => pathname.startsWith(to);
   return (

--- a/src/spa/admin/users/PageUserCreate.tsx
+++ b/src/spa/admin/users/PageUserCreate.tsx
@@ -11,7 +11,7 @@ import { useUserCreate } from '@/spa/admin/users/users.service';
 import { Page, PageBottomBar, PageContent, PageTopBar } from '@/spa/layout';
 
 export const PageUserCreate = () => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['common', 'users']);
   const navigate = useNavigate();
   const form = useForm({ subscribe: false });
 
@@ -72,7 +72,7 @@ export const PageUserCreate = () => {
           <PageBottomBar>
             <ButtonGroup justifyContent="space-between">
               <Button onClick={() => navigate(-1)}>
-                {t('actions.cancel')}
+                {t('common:actions.cancel')}
               </Button>
               <Button
                 type="submit"

--- a/src/spa/admin/users/PageUserUpdate.tsx
+++ b/src/spa/admin/users/PageUserUpdate.tsx
@@ -29,7 +29,7 @@ import { UserForm } from './UserForm';
 import { UserStatus } from './UserStatus';
 
 export const PageUserUpdate = () => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['common', 'users']);
 
   const { login } = useParams();
   const navigate = useNavigate();
@@ -125,7 +125,7 @@ export const PageUserUpdate = () => {
             <PageBottomBar>
               <ButtonGroup justifyContent="space-between">
                 <Button onClick={() => navigate(-1)}>
-                  {t('actions.cancel')}
+                  {t('common:actions.cancel')}
                 </Button>
                 <Button
                   type="submit"

--- a/src/spa/admin/users/PageUsers.tsx
+++ b/src/spa/admin/users/PageUsers.tsx
@@ -74,7 +74,7 @@ type UserActionProps = Omit<MenuProps, 'children'> & {
 };
 
 const UserActions = ({ user, ...rest }: UserActionProps) => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['common', 'users']);
   const toastSuccess = useToastSuccess();
   const toastError = useToastError();
   const { mutate: userUpdate, ...userUpdateData } = useUserUpdate({
@@ -152,14 +152,14 @@ const UserActions = ({ user, ...rest }: UserActionProps) => {
             to={user.login}
             icon={<Icon icon={FiEdit} fontSize="lg" color="gray.400" />}
           >
-            {t('actions.edit')}
+            {t('common:actions.edit')}
           </MenuItem>
           {user.activated ? (
             <MenuItem
               onClick={deactivateUser}
               icon={<Icon icon={FiXCircle} fontSize="lg" color="gray.400" />}
             >
-              {t('actions.deactivate')}
+              {t('common:actions.deactivate')}
             </MenuItem>
           ) : (
             <MenuItem
@@ -168,7 +168,7 @@ const UserActions = ({ user, ...rest }: UserActionProps) => {
                 <Icon icon={FiCheckCircle} fontSize="lg" color="gray.400" />
               }
             >
-              {t('actions.activate')}
+              {t('common:actions.activate')}
             </MenuItem>
           )}
           <MenuDivider />
@@ -176,7 +176,7 @@ const UserActions = ({ user, ...rest }: UserActionProps) => {
             icon={<Icon icon={FiTrash2} fontSize="lg" color="gray.400" />}
             onClick={removeUser}
           >
-            {t('actions.delete')}
+            {t('common:actions.delete')}
           </ConfirmMenuItem>
         </MenuList>
       </Portal>
@@ -185,7 +185,7 @@ const UserActions = ({ user, ...rest }: UserActionProps) => {
 };
 
 export const PageUsers = () => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['users']);
   const { page, setPage } = usePaginationFromUrl();
   const pageSize = 20;
   const { users, totalItems, isLoadingPage, isError, refetch } = useUserList({

--- a/src/spa/admin/users/UserForm.tsx
+++ b/src/spa/admin/users/UserForm.tsx
@@ -20,7 +20,7 @@ const AUTHORITIES = {
 };
 
 export const UserForm = () => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['common', 'users']);
 
   const authorities = Object.values(AUTHORITIES).map((value) => ({ value }));
   return (
@@ -81,7 +81,7 @@ export const UserForm = () => {
         name="langKey"
         label={t('users:data.language.label')}
         options={AVAILABLE_LANGUAGES.map(({ key }) => ({
-          label: t(`languages.${key}`),
+          label: t(`common:languages.${key}`),
           value: key,
         }))}
         defaultValue={DEFAULT_LANGUAGE_KEY}

--- a/src/spa/admin/users/UserStatus.tsx
+++ b/src/spa/admin/users/UserStatus.tsx
@@ -5,7 +5,7 @@ import { FiCheck, FiX } from 'react-icons/fi';
 import { Icon } from '@/components/Icons';
 
 export const UserStatus = ({ isActivated = false, ...rest }) => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['users']);
   return isActivated ? (
     <Badge size="sm" colorScheme="success" {...rest}>
       <Box as="span" display={{ base: 'none', md: 'block' }}>

--- a/src/spa/auth/LoginForm.tsx
+++ b/src/spa/auth/LoginForm.tsx
@@ -18,7 +18,7 @@ import { useToastError } from '@/components/Toast';
 import { useLogin } from '@/spa/auth/auth.service';
 
 const MockedApiHint = () => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['auth']);
   const form = useForm({ subscribe: 'form' });
   const mockedUsername = 'admin';
   const mockedPassword = 'admin';
@@ -58,7 +58,7 @@ export const LoginForm = ({
   onSuccess = () => undefined,
   ...rest
 }: LoginFormProps) => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['auth']);
   const form = useForm({ subscribe: 'form' });
   const toastError = useToastError();
 

--- a/src/spa/auth/LoginModalInterceptor.tsx
+++ b/src/spa/auth/LoginModalInterceptor.tsx
@@ -19,7 +19,7 @@ import { useAuthContext } from '@/spa/auth/AuthContext';
 import { LoginForm } from '@/spa/auth/LoginForm';
 
 export const LoginModalInterceptor = () => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['auth']);
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { isAuthenticated, updateToken } = useAuthContext();
   const queryCache = useQueryClient();

--- a/src/spa/auth/PageLogin.tsx
+++ b/src/spa/auth/PageLogin.tsx
@@ -11,7 +11,7 @@ import { LoginForm } from '@/spa/auth/LoginForm';
 import { useRedirectFromUrl } from '@/spa/router';
 
 export const PageLogin = () => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['auth']);
   const redirect = useRedirectFromUrl();
   const queryCache = useQueryClient();
   const onLogin = () => {

--- a/src/spa/dashboard/PageDashboard.tsx
+++ b/src/spa/dashboard/PageDashboard.tsx
@@ -19,7 +19,7 @@ import { Icon } from '@/components/Icons';
 import { Page, PageContent } from '@/spa/layout';
 
 export const PageDashboard = () => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['dashboard']);
   return (
     <Page>
       <PageContent>

--- a/src/spa/layout/AccountMenu/index.tsx
+++ b/src/spa/layout/AccountMenu/index.tsx
@@ -31,7 +31,7 @@ import { Icon } from '@/components/Icons';
 import { useAccount } from '@/spa/account/account.service';
 
 const AppVersion = ({ ...rest }) => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['layout']);
 
   const { hasCopied, onCopy } = useClipboard(
     JSON.stringify(buildInfo, null, 2)
@@ -102,7 +102,7 @@ const AppVersion = ({ ...rest }) => {
 };
 
 export const AccountMenu = ({ ...rest }) => {
-  const { t } = useTranslation('layout');
+  const { t } = useTranslation(['layout']);
 
   const { colorMode, toggleColorMode } = useColorMode();
   const { account, isLoading } = useAccount();

--- a/src/spa/layout/MainMenu/index.tsx
+++ b/src/spa/layout/MainMenu/index.tsx
@@ -61,7 +61,7 @@ const MainMenuItem = ({ to, ...rest }: BoxProps & { to: string }) => {
 };
 
 export const MainMenu = ({ ...rest }) => {
-  const { t } = useTranslation();
+  const { t } = useTranslation(['layout']);
   const { isAdmin } = useAccount();
   return (
     <Stack direction="row" spacing="1" {...rest}>

--- a/src/types/i18next.d.ts
+++ b/src/types/i18next.d.ts
@@ -1,9 +1,15 @@
 import 'i18next';
 
+import { DEFAULT_NAMESPACE } from '@/constants/i18n';
+import locales from '@/locales';
+
 // Fix issue with i18next types
 // https://www.i18next.com/overview/typescript#argument-of-type-defaulttfuncreturn-is-not-assignable-to-parameter-of-type-xyz
+
 declare module 'i18next' {
   interface CustomTypeOptions {
     returnNull: false;
+    defaultNS: typeof DEFAULT_NAMESPACE;
+    resources: typeof locales['en'];
   }
 }


### PR DESCRIPTION
This PR adds type safety to i18n, based on its [documentation](https://www.i18next.com/overview/typescript).

Module imports have no types inferred by TS so they had to be changed to objects declared `as const`.

Calls to the default namespace `common` without `common:` had to add it explicitly due to an ongoing issue. https://github.com/i18next/react-i18next/issues/1422 https://github.com/i18next/i18next/issues/1855
