### PR TITLE
feat: documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@
 🚀 Start UI <small>[web]</small> is an opinionated frontend starter repository created & maintained by the [BearStudio Team](https://www.bearstudio.fr/team) and other contributors.
 It represents our team's up-to-date stack that we use when creating web apps for our clients.
 
+## Documentation
+
+For detailed information on how to use this project, please refer to the [documentation](https://docs.web.start-ui.com). The documentation contains all the necessary information on installation, usage, and some guides.
+
+## Demo
+
+A live demonstration of what you will have when starting a project with 🚀 Start UI <small>[web]</small> is available on [demo.start-ui.com](https://demo.start-ui.com)
+
+
 ## Getting Started
 
 ```bash
@@ -43,6 +52,8 @@ yarn dev
 ℹ️ API calls are mapped on a [JHipster](https://www.jhipster.tech/) backend application.
 
 ## Features
+
+You can find more details about each feature on the [documentation](https://docs.web.start-ui.com)
 
 - Reponsive layout / navigation.
 - Sign / Sign Up / Password recovery screens.

--- a/src/locales/ar/dashboard.json
+++ b/src/locales/ar/dashboard.json
@@ -1,7 +1,8 @@
 {
   "links": {
     "github": "مستودع Github",
-    "openIssue": "إفتح مشكلة"
+    "openIssue": "إفتح مشكلة",
+    "documentation": "توثيق"
   },
   "title": "اللوحة الرئيسية",
   "welcome": {

--- a/src/locales/en/dashboard.json
+++ b/src/locales/en/dashboard.json
@@ -7,6 +7,7 @@
   },
   "links": {
     "github": "GitHub Repository",
-    "openIssue": "Open Issue"
+    "openIssue": "Open Issue",
+    "documentation": "Documentation"
   }
 }

--- a/src/locales/fr/dashboard.json
+++ b/src/locales/fr/dashboard.json
@@ -7,6 +7,7 @@
   },
   "links": {
     "github": "Dépôt GitHub",
-    "openIssue": "Ouvrir une issue"
+    "openIssue": "Ouvrir une issue",
+    "documentation": "Documentation"
   }
 }

--- a/src/locales/sw/dashboard.json
+++ b/src/locales/sw/dashboard.json
@@ -7,6 +7,7 @@
   },
   "links": {
     "github": "Github hazina",
-    "openIssue": "Fungua njia ya kutoka"
+    "openIssue": "Fungua njia ya kutoka",
+    "documentation": "nyaraka"
   }
 }

--- a/src/spa/dashboard/PageDashboard.tsx
+++ b/src/spa/dashboard/PageDashboard.tsx
@@ -7,9 +7,9 @@ import {
   AlertTitle,
   Box,
   Button,
-  ButtonGroup,
   Heading,
   Text,
+  Wrap,
 } from '@chakra-ui/react';
 import { Trans, useTranslation } from 'react-i18next';
 import { CgLoadbarDoc } from 'react-icons/cg';
@@ -42,7 +42,7 @@ export const PageDashboard = () => {
             </AlertDescription>
           </Box>
         </Alert>
-        <ButtonGroup mt="4" spacing="4">
+        <Wrap mt="4" spacing="4">
           <Button
             variant="link"
             as="a"
@@ -62,7 +62,7 @@ export const PageDashboard = () => {
             <Icon icon={FiAlertCircle} me="1" />{' '}
             {t('dashboard:links.openIssue')}
           </Button>
-        </ButtonGroup>
+        </Wrap>
       </PageContent>
     </Page>
   );

--- a/src/spa/dashboard/PageDashboard.tsx
+++ b/src/spa/dashboard/PageDashboard.tsx
@@ -12,6 +12,7 @@ import {
   Text,
 } from '@chakra-ui/react';
 import { Trans, useTranslation } from 'react-i18next';
+import { CgLoadbarDoc } from 'react-icons/cg';
 import { FaGithub } from 'react-icons/fa';
 import { FiAlertCircle } from 'react-icons/fi';
 
@@ -48,6 +49,10 @@ export const PageDashboard = () => {
             href="https://github.com/BearStudio/start-ui"
           >
             <Icon icon={FaGithub} me="1" /> {t('dashboard:links.github')}
+          </Button>
+          <Button variant="link" as="a" href="https://docs.web.start-ui.com">
+            <Icon icon={CgLoadbarDoc} me="1" />{' '}
+            {t('dashboard:links.documentation')}
           </Button>
           <Button
             variant="link"


### PR DESCRIPTION
Add documentation links in README and on PageDashboard

Mobile : 
<img width="266" alt="image" src="https://user-images.githubusercontent.com/48803115/209918293-b74b15a1-1c97-4489-a196-c04e12358135.png">

Desktop :
![image](https://user-images.githubusercontent.com/48803115/209918236-419efcd5-f605-48e4-98e8-546e1e052df8.png)
