### PR TITLE
feat: remove next-env.d.ts from versionning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ yarn-error.log*
 
 # Build info
 .build-info.json
+next-env.d.ts

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.


### PR DESCRIPTION
As stated by the Next documentation:

A file named next-env.d.ts will be created at the root of your project. This file ensures Next.js types are picked up by the TypeScript compiler. You should not remove it or edit it as it can change at any time. This file should not be committed and should be ignored by version control (e.g. inside your .gitignore file).