### PR TITLE
fix daypicker click when input is not visible

### DIFF
--- a/src/components/DayPicker/index.tsx
+++ b/src/components/DayPicker/index.tsx
@@ -140,6 +140,7 @@ export const DayPicker: FC<React.PropsWithChildren<DayPickerProps>> = ({
         parseDate={parseDate}
         placeholder={placeholder}
         value={value ?? undefined}
+        keepFocus={false}
         dayPickerProps={{
           dir: theme.direction,
           locale: i18n.language,


### PR DESCRIPTION
## Describe your changes
When the input is not visible, we cannot choose a date.
closes #307 

To fix this issue, we can add the keepFocus={false} attribute to the DayPickerInput component. This attribute disables the focus on the input after the user selects a date. 

## Screenshots

### Before 

https://user-images.githubusercontent.com/80390318/213213521-1b24ee2e-ff0f-4298-ac77-c5a96bbfd271.mp4


### After

https://user-images.githubusercontent.com/80390318/213213334-73312dc6-7ccb-410a-9d94-8c68a07727ad.mp4


## Checklist

 - [x] I performed a self review of my code
 - [x] I ensured that everything is written in English
 - [x] I tested the feature or fix on my local environment
 - [x] I ran the `yarn storybook` command and everything is working
 - [ ] If applicable, I updated the translations for english and french files  
      (If you cannot update the french language, just let us know in the PR description)
 - [ ] If applicable, I updated the README.md
 - [ ] If applicable, I created a PR or an issue on the [documentation repository](https://github.com/bearstudio/start-ui-web-docs/)
 - [x] If applicable, I’m sure that my feature or my component is mobile first and available correctly on desktop




