### PR TITLE
Allows prettier in .env.validator.js

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,3 +11,4 @@ public
 *.md
 *.mdx
 .env*
+!.env.validator.js


### PR DESCRIPTION
.env.validator.js was ignored by prettier