### PR TITLE
fix: redirect unauthenticated on admin routes

### DIFF
--- a/src/spa/router/guards/AdminRouteGuard.tsx
+++ b/src/spa/router/guards/AdminRouteGuard.tsx
@@ -3,11 +3,14 @@ import { FC } from 'react';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { ErrorPage } from '@/components/ErrorPage';
 import { useAccount } from '@/spa/account/account.service';
+import { useRedirectUnauthenticated } from '@/spa/router/guards/useRedirectUnauthenticated';
 
 export const AdminRouteGuard: FC<React.PropsWithChildren<unknown>> = ({
   children,
 }) => {
   const { isAdmin, isLoading } = useAccount();
+
+  useRedirectUnauthenticated();
 
   if (isLoading) {
     return null;

--- a/src/spa/router/guards/AuthenticatedRouteGuard.tsx
+++ b/src/spa/router/guards/AuthenticatedRouteGuard.tsx
@@ -1,24 +1,15 @@
-import { FC, useEffect } from 'react';
-
-import { useLocation, useNavigate } from 'react-router-dom';
+import { FC } from 'react';
 
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { useAuthContext } from '@/spa/auth/AuthContext';
+import { useRedirectUnauthenticated } from '@/spa/router/guards/useRedirectUnauthenticated';
 
 export const AuthenticatedRouteGuard: FC<React.PropsWithChildren<unknown>> = ({
   children,
 }) => {
   const { isAuthenticated } = useAuthContext();
-  const { pathname, search } = useLocation();
-  const navigate = useNavigate();
 
-  useEffect(() => {
-    if (!isAuthenticated) {
-      navigate(`/login?redirect=${encodeURIComponent(pathname + search)}`, {
-        replace: true,
-      });
-    }
-  }, [isAuthenticated, navigate, pathname, search]);
+  useRedirectUnauthenticated();
 
   return !isAuthenticated ? null : <ErrorBoundary>{children}</ErrorBoundary>;
 };

--- a/src/spa/router/guards/useRedirectUnauthenticated.ts
+++ b/src/spa/router/guards/useRedirectUnauthenticated.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+
+import { useLocation, useNavigate } from 'react-router-dom';
+
+import { useAuthContext } from '@/spa/auth/AuthContext';
+
+export const useRedirectUnauthenticated = () => {
+  const { isAuthenticated } = useAuthContext();
+  const { pathname, search } = useLocation();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      navigate(`/login?redirect=${encodeURIComponent(pathname + search)}`, {
+        replace: true,
+      });
+    }
+  }, [isAuthenticated, navigate, pathname, search]);
+};


### PR DESCRIPTION
## Describe your changes

closes #340

Navigate to admin page unauthenticated does not redirect on login page like that should (and like it works on non-admin page like dashboard)


## Screenshots

Result : 
![image](https://user-images.githubusercontent.com/48803115/232046143-6ddeceab-7056-4390-a64c-1e1d5fd0155e.png)

## Checklist

 - [x] I performed a self review of my code
 - [x] I ensured that everything is written in English
 - [x] I tested the feature or fix on my local environment
 - [x] I ran the `yarn storybook` command and everything is working




