### PR TITLE
refactor: new usage useDisclosure return

### DIFF
--- a/src/components/ConfirmModal/index.tsx
+++ b/src/components/ConfirmModal/index.tsx
@@ -40,7 +40,7 @@ export const ConfirmModal: React.FC<
   ...rest
 }) => {
   const { t } = useTranslation(['common', 'components']);
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const confirmModal = useDisclosure();
 
   const displayHeading =
     !title && !message ? t('components:confirmModal.heading') : title;
@@ -55,15 +55,15 @@ export const ConfirmModal: React.FC<
   }
 
   const childrenWithOnOpen = React.cloneElement(children, {
-    onClick: onOpen,
+    onClick: confirmModal.onOpen,
   });
 
   return (
     <>
       {childrenWithOnOpen}
       <Modal
-        isOpen={isOpen}
-        onClose={onClose}
+        isOpen={confirmModal.isOpen}
+        onClose={confirmModal.onClose}
         size="xs"
         initialFocusRef={initialFocusRef}
         {...rest}
@@ -81,14 +81,14 @@ export const ConfirmModal: React.FC<
             </ModalBody>
             <ModalFooter>
               <ButtonGroup justifyContent="space-between" w="full">
-                <Button onClick={onClose}>
+                <Button onClick={confirmModal.onClose}>
                   {cancelText ?? t('common:actions.cancel')}
                 </Button>
                 <Button
                   variant={confirmVariant}
                   onClick={() => {
                     onConfirm();
-                    onClose();
+                    confirmModal.onClose();
                   }}
                   ref={initialFocusRef}
                 >

--- a/src/components/ConfirmPopover/index.tsx
+++ b/src/components/ConfirmPopover/index.tsx
@@ -42,7 +42,7 @@ export const ConfirmPopover: React.FC<
   ...rest
 }) => {
   const { t } = useTranslation(['common', 'components']);
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const confirmPopover = useDisclosure();
 
   const displayHeading =
     !title && !message ? t('components:confirmPopover.heading') : title;
@@ -60,9 +60,9 @@ export const ConfirmPopover: React.FC<
     <>
       <Popover
         isLazy
-        isOpen={isOpen}
-        onClose={onClose}
-        onOpen={onOpen}
+        isOpen={confirmPopover.isOpen}
+        onClose={confirmPopover.onClose}
+        onOpen={confirmPopover.onOpen}
         initialFocusRef={initialFocusRef}
         {...rest}
       >
@@ -81,14 +81,14 @@ export const ConfirmPopover: React.FC<
               </PopoverBody>
               <PopoverFooter>
                 <ButtonGroup size="sm" justifyContent="space-between" w="full">
-                  <Button onClick={onClose}>
+                  <Button onClick={confirmPopover.onClose}>
                     {cancelText ?? t('common:actions.cancel')}
                   </Button>
                   <Button
                     variant={confirmVariant}
                     onClick={() => {
                       onConfirm();
-                      onClose();
+                      confirmPopover.onClose();
                     }}
                     ref={initialFocusRef}
                   >

--- a/src/components/DateSelector/DateSelector.tsx
+++ b/src/components/DateSelector/DateSelector.tsx
@@ -30,16 +30,22 @@ export const DateSelector: FC<React.PropsWithChildren<DateSelectorProps>> = ({
   onChange,
   ...rest
 }) => {
-  const { isOpen, onClose, onOpen } = useDisclosure();
+  const dayPicker = useDisclosure();
 
   const onDayClick = (d: Dayjs) => {
     onChange(d);
-    onClose();
+    dayPicker.onClose();
   };
 
   return (
     <DateSelectorContext.Provider
-      value={{ date, onDayClick, isOpen, onClose, onOpen }}
+      value={{
+        date,
+        onDayClick,
+        isOpen: dayPicker.isOpen,
+        onClose: dayPicker.onClose,
+        onOpen: dayPicker.onOpen,
+      }}
     >
       <Flex alignItems="center" {...rest} />
     </DateSelectorContext.Provider>

--- a/src/components/ErrorBoundary/index.tsx
+++ b/src/components/ErrorBoundary/index.tsx
@@ -22,7 +22,7 @@ import {
 import { useTranslation } from 'react-i18next';
 
 const ErrorFallback = ({ error }: FallbackProps) => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const errorModal = useDisclosure();
   const { t } = useTranslation(['components']);
   return (
     <Box p="4" m="auto">
@@ -35,13 +35,13 @@ const ErrorFallback = ({ error }: FallbackProps) => {
               variant="link"
               size="sm"
               textDecoration="underline"
-              onClick={onOpen}
+              onClick={errorModal.onOpen}
               color="red.800"
               _dark={{ color: 'red.100' }}
             >
               {t('components:errorBoundary.actions.expand')}
             </Button>
-            <Modal isOpen={isOpen} onClose={onClose}>
+            <Modal isOpen={errorModal.isOpen} onClose={errorModal.onClose}>
               <ModalOverlay />
               <ModalContent>
                 <ModalHeader>{t('components:errorBoundary.title')}</ModalHeader>

--- a/src/components/Select/docs.stories.tsx
+++ b/src/components/Select/docs.stories.tsx
@@ -186,12 +186,12 @@ export const SelectInPopover = () => {
 };
 
 export const SelectInModal = () => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const modal = useDisclosure();
   return (
     <>
-      <Button onClick={onOpen}>Open Modal</Button>
+      <Button onClick={modal.onOpen}>Open Modal</Button>
 
-      <Modal isOpen={isOpen} onClose={onClose}>
+      <Modal isOpen={modal.isOpen} onClose={modal.onClose}>
         <ModalOverlay />
         <ModalContent>
           <ModalHeader>Modal Title</ModalHeader>
@@ -201,7 +201,7 @@ export const SelectInModal = () => {
           </ModalBody>
 
           <ModalFooter>
-            <Button colorScheme="blue" onClick={onClose}>
+            <Button colorScheme="blue" onClick={modal.onClose}>
               Close
             </Button>
           </ModalFooter>

--- a/src/spa/auth/LoginModalInterceptor.tsx
+++ b/src/spa/auth/LoginModalInterceptor.tsx
@@ -20,13 +20,15 @@ import { LoginForm } from '@/spa/auth/LoginForm';
 
 export const LoginModalInterceptor = () => {
   const { t } = useTranslation(['auth']);
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const loginModal = useDisclosure();
   const { isAuthenticated, updateToken } = useAuthContext();
   const queryCache = useQueryClient();
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const pathnameRef = useRef(pathname);
   pathnameRef.current = pathname;
+
+  const openLoginModal = loginModal.onOpen;
 
   useEffect(() => {
     const interceptor = Axios.interceptors.response.use(
@@ -37,37 +39,37 @@ export const LoginModalInterceptor = () => {
           pathnameRef.current !== '/login'
         ) {
           queryCache.cancelQueries();
-          onOpen();
+          openLoginModal();
         }
         throw error;
       }
     );
 
     return () => Axios.interceptors.response.eject(interceptor);
-  }, [onOpen, updateToken, queryCache]);
+  }, [openLoginModal, updateToken, queryCache]);
 
   // On Route Change
   useEffect(() => {
-    if (isOpen && pathname !== pathnameRef.current) {
+    if (loginModal.isOpen && pathname !== pathnameRef.current) {
       updateToken(null);
-      onClose();
+      loginModal.onClose();
     }
-  }, [isOpen, updateToken, onClose, pathname]);
+  }, [loginModal, updateToken, pathname]);
 
   const handleLogin = () => {
     queryCache.refetchQueries();
-    onClose();
+    loginModal.onClose();
   };
 
   const handleClose = () => {
     updateToken(null);
-    onClose();
+    loginModal.onClose();
     navigate('/login');
   };
 
   return (
     <Modal
-      isOpen={isOpen && isAuthenticated}
+      isOpen={loginModal.isOpen && isAuthenticated}
       onClose={handleClose}
       closeOnOverlayClick={false}
       trapFocus={false}

--- a/src/spa/layout/Layout/index.tsx
+++ b/src/spa/layout/Layout/index.tsx
@@ -10,11 +10,7 @@ import { LayoutContext, TopBar } from '@/spa/layout';
 
 export const Layout: FC<React.PropsWithChildren<unknown>> = ({ children }) => {
   const [isFocusMode, setIsFocusMode] = useState(false);
-  const {
-    isOpen: navIsOpen,
-    onClose: navOnClose,
-    onOpen: navOnOpen,
-  } = useDisclosure();
+  const nav = useDisclosure();
   const { isAuthenticated } = useAuthContext();
   const { pathname } = useLocation();
 
@@ -24,7 +20,13 @@ export const Layout: FC<React.PropsWithChildren<unknown>> = ({ children }) => {
 
   return (
     <LayoutContext.Provider
-      value={{ isFocusMode, setIsFocusMode, navIsOpen, navOnClose, navOnOpen }}
+      value={{
+        isFocusMode,
+        setIsFocusMode,
+        navIsOpen: nav.isOpen,
+        navOnClose: nav.onClose,
+        navOnOpen: nav.onOpen,
+      }}
     >
       <Viewport>
         {isAuthenticated && !isFocusMode && <TopBar />}

--- a/src/spa/layout/Layout/index.tsx
+++ b/src/spa/layout/Layout/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useEffect, useMemo, useState } from 'react';
 
 import { Flex, useDisclosure } from '@chakra-ui/react';
 import { useLocation } from 'react-router-dom';
@@ -18,16 +18,19 @@ export const Layout: FC<React.PropsWithChildren<unknown>> = ({ children }) => {
     window.scrollTo(0, 0);
   }, [pathname]);
 
+  const providerValue = useMemo(
+    () => ({
+      isFocusMode,
+      setIsFocusMode,
+      navIsOpen: nav.isOpen,
+      navOnClose: nav.onClose,
+      navOnOpen: nav.onOpen,
+    }),
+    [isFocusMode, nav.isOpen, nav.onClose, nav.onOpen]
+  );
+
   return (
-    <LayoutContext.Provider
-      value={{
-        isFocusMode,
-        setIsFocusMode,
-        navIsOpen: nav.isOpen,
-        navOnClose: nav.onClose,
-        navOnOpen: nav.onOpen,
-      }}
-    >
+    <LayoutContext.Provider value={providerValue}>
       <Viewport>
         {isAuthenticated && !isFocusMode && <TopBar />}
         <Flex flex="1" direction="column">

--- a/src/theme/styleguide/modals.stories.mdx
+++ b/src/theme/styleguide/modals.stories.mdx
@@ -33,11 +33,11 @@ import {
 <Canvas>
   <Story name="Default">
     {(() => {
-      const { isOpen, onOpen, onClose } = useDisclosure()
+      const modal = useDisclosure()
       return (
         <>
-          <Button onClick={onOpen}>Open Modal</Button>
-          <Modal isOpen={isOpen} onClose={onClose}>
+          <Button onClick={modal.onOpen}>Open Modal</Button>
+          <Modal isOpen={modal.isOpen} onClose={modal.onClose}>
             <ModalOverlay />
             <ModalContent>
               <ModalHeader>Modal Title</ModalHeader>
@@ -47,10 +47,10 @@ import {
               </ModalBody>
               <ModalFooter>
                 <ButtonGroup justifyContent="space-between" w="full">
-                  <Button onClick={onClose}>
+                  <Button onClick={modal.onClose}>
                     Cancel
                   </Button>
-                  <Button variant="@primary" onClick={onClose}>Action</Button>
+                  <Button variant="@primary" onClick={modal.onClose}>Action</Button>
                 </ButtonGroup>
               </ModalFooter>
             </ModalContent>
@@ -66,11 +66,11 @@ import {
 <Canvas>
   <Story name="WithoutHeader">
     {(() => {
-      const { isOpen, onOpen, onClose } = useDisclosure()
+      const modal = useDisclosure()
       return (
         <>
-          <Button onClick={onOpen}>Open Modal</Button>
-          <Modal isOpen={isOpen} onClose={onClose}>
+          <Button onClick={modal.onOpen}>Open Modal</Button>
+          <Modal isOpen={modal.isOpen} onClose={modal.onClose}>
             <ModalOverlay />
             <ModalContent>
               <ModalBody>
@@ -78,10 +78,10 @@ import {
               </ModalBody>
               <ModalFooter>
                 <ButtonGroup justifyContent="space-between" w="full">
-                  <Button onClick={onClose}>
+                  <Button onClick={modal.onClose}>
                     Cancel
                   </Button>
-                  <Button variant="@primary" onClick={onClose}>Action</Button>
+                  <Button variant="@primary" onClick={modal.onClose}>Action</Button>
                 </ButtonGroup>
               </ModalFooter>
             </ModalContent>
@@ -98,21 +98,21 @@ import {
 <Canvas>
   <Story name="WithoutBody">
     {(() => {
-      const { isOpen, onOpen, onClose } = useDisclosure()
+      const modal = useDisclosure()
       return (
         <>
-          <Button onClick={onOpen}>Open Modal</Button>
-          <Modal isOpen={isOpen} onClose={onClose}>
+          <Button onClick={modal.onOpen}>Open Modal</Button>
+          <Modal isOpen={modal.isOpen} onClose={modal.onClose}>
             <ModalOverlay />
             <ModalContent>
               <ModalHeader>Modal Title</ModalHeader>
               <ModalCloseButton />
               <ModalFooter>
                 <ButtonGroup justifyContent="space-between" w="full">
-                  <Button onClick={onClose}>
+                  <Button onClick={modal.onClose}>
                     Cancel
                   </Button>
-                  <Button variant="@primary" onClick={onClose}>Action</Button>
+                  <Button variant="@primary" onClick={modal.onClose}>Action</Button>
                 </ButtonGroup>
               </ModalFooter>
             </ModalContent>
@@ -128,11 +128,11 @@ import {
 <Canvas>
   <Story name="WithoutFooter">
     {(() => {
-      const { isOpen, onOpen, onClose } = useDisclosure()
+      const modal = useDisclosure()
       return (
         <>
-          <Button onClick={onOpen}>Open Modal</Button>
-          <Modal isOpen={isOpen} onClose={onClose}>
+          <Button onClick={modal.onOpen}>Open Modal</Button>
+          <Modal isOpen={modal.isOpen} onClose={modal.onClose}>
             <ModalOverlay />
             <ModalContent>
               <ModalHeader>Modal Title</ModalHeader>
@@ -154,11 +154,11 @@ import {
 <Canvas>
   <Story name="BodyOnly">
     {(() => {
-      const { isOpen, onOpen, onClose } = useDisclosure()
+      const modal = useDisclosure()
       return (
         <>
-          <Button onClick={onOpen}>Open Modal</Button>
-          <Modal isOpen={isOpen} onClose={onClose}>
+          <Button onClick={modal.onOpen}>Open Modal</Button>
+          <Modal isOpen={modal.isOpen} onClose={modal.onClose}>
             <ModalOverlay />
             <ModalContent>
               <ModalCloseButton />
@@ -179,11 +179,11 @@ import {
 <Canvas>
   <Story name="Full">
     {(() => {
-      const { isOpen, onOpen, onClose } = useDisclosure()
+      const modal = useDisclosure()
       return (
         <>
-          <Button onClick={onOpen}>Open Modal</Button>
-          <Modal isOpen={isOpen} onClose={onClose} size="full">
+          <Button onClick={modal.onOpen}>Open Modal</Button>
+          <Modal isOpen={modal.isOpen} onClose={modal.onClose} size="full">
             <ModalOverlay />
             <ModalContent>
               <ModalHeader>Modal Title</ModalHeader>
@@ -193,10 +193,10 @@ import {
               </ModalBody>
               <ModalFooter>
                 <ButtonGroup justifyContent="space-between" w="full">
-                  <Button onClick={onClose}>
+                  <Button onClick={modal.onClose}>
                     Cancel
                   </Button>
-                  <Button variant="@primary" onClick={onClose}>Action</Button>
+                  <Button variant="@primary" onClick={modal.onClose}>Action</Button>
                 </ButtonGroup>
               </ModalFooter>
             </ModalContent>

--- a/src/theme/styleguide/popovers.stories.mdx
+++ b/src/theme/styleguide/popovers.stories.mdx
@@ -11,7 +11,6 @@ import {
   Portal,
   Button,
   ButtonGroup,
-  useDisclosure,
  } from '@chakra-ui/react'
 import { Meta, Story, Canvas } from '@storybook/addon-docs';
 


### PR DESCRIPTION
## Describe your changes

Like the usage of useQuery (https://github.com/BearStudio/start-ui-web/pull/342), I think it's a better idea to not destructure ChakraUI `useDisclosure` return value, because it's more readable and that simplify disclosure definition and refactor.

For example :
Not readable or complex :
```
const { isOpen, onOpen, onClose } = useDisclosure();
const { isOpen: isOpenConfirmModal, onOpen: onOpenConfirmModal, onClose: onCloseConfirmModal } = useDisclosure();

...

<Button onClick={onOpen}>Open</Button> 
<Button onClick={onOpenConfirmModal}>Open</Button>
```
Easier and more readable :
```
const confirmModal = useDisclosure();

...

<Button onClick={confirmModal.onOpen}>Open</Button>
```


## Checklist

 - [x] I performed a self review of my code
 - [x] I ensured that everything is written in English
 - [x] I tested the feature or fix on my local environment
 - [x] I ran the `yarn storybook` command and everything is working




