### PR TITLE
feat(theme): add custom color mode storage key

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,14 @@ Update the `NEXT_PUBLIC_API_BASE_URL` with your JHipster API url:
 NEXT_PUBLIC_API_BASE_URL="http://localhost:8080/api"
 ```
 
+### Update color mode storage key
+
+You can update the storage key used to detect the color mode by updating this constant in the `src/theme/config.ts` file:
+
+```tsx
+export const COLOR_MODE_STORAGE_KEY = 'start-ui-color-mode'; // Update the key according to your needs
+```
+
 ## Show hint on development environments
 
 Setup the `NEXT_PUBLIC_DEV_ENV_NAME` env variable with the name of the environment.

--- a/src/app/Document.tsx
+++ b/src/app/Document.tsx
@@ -11,7 +11,7 @@ import { DemoModalInterceptor } from '@/features/demo-mode/DemoModalInterceptor'
 import { EnvDevHint } from '@/layout/EnvDevHint';
 import i18n from '@/lib/i18n/config';
 import { AVAILABLE_LANGUAGES } from '@/lib/i18n/constants';
-import { theme } from '@/theme/theme';
+import theme, { COLOR_MODE_STORAGE_KEY } from '@/theme';
 
 export const Document = ({ children }: { children: ReactNode }) => {
   return (
@@ -64,7 +64,11 @@ export const Document = ({ children }: { children: ReactNode }) => {
       </head>
       <body>
         {/* https://github.com/chakra-ui/chakra-ui/issues/7040 */}
-        <ColorModeScript initialColorMode={theme.config.initialColorMode} />
+        <ColorModeScript
+          initialColorMode={theme.config.initialColorMode}
+          storageKey={COLOR_MODE_STORAGE_KEY}
+        />
+
         <Providers>
           <Viewport>{children}</Viewport>
           <EnvDevHint />

--- a/src/app/Providers.tsx
+++ b/src/app/Providers.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 
 import { CacheProvider } from '@chakra-ui/next-js';
-import { ChakraProvider } from '@chakra-ui/react';
+import { ChakraProvider, createLocalStorageManager } from '@chakra-ui/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 
@@ -10,9 +10,11 @@ import '@/lib/axios/config';
 import '@/lib/dayjs/config';
 import '@/lib/i18n/config';
 import { AVAILABLE_LANGUAGES } from '@/lib/i18n/constants';
-import theme from '@/theme';
+import theme, { COLOR_MODE_STORAGE_KEY } from '@/theme';
 
 const queryClient = new QueryClient();
+
+const localStorageManager = createLocalStorageManager(COLOR_MODE_STORAGE_KEY);
 
 export const Providers: FC<React.PropsWithChildren<unknown>> = ({
   children,
@@ -24,6 +26,7 @@ export const Providers: FC<React.PropsWithChildren<unknown>> = ({
       <AuthProvider>
         <CacheProvider>
           <ChakraProvider
+            colorModeManager={localStorageManager}
             theme={{
               ...theme,
               direction:

--- a/src/theme/config.ts
+++ b/src/theme/config.ts
@@ -4,3 +4,5 @@ export const config: ThemeConfig = {
   initialColorMode: 'light',
   useSystemColorMode: false,
 };
+
+export const COLOR_MODE_STORAGE_KEY = 'start-ui-color-mode';

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,3 +1,4 @@
 import './externals-css';
 
 export { theme as default } from './theme';
+export { COLOR_MODE_STORAGE_KEY } from './config';


### PR DESCRIPTION
## Describe your changes

The idea is to give the user the ability to easily update the storage key used by chakra-ui to update the color mode.

This will prevent color mode conflicts when you have multiple projects using chakra-ui stack.

For implementation details, see: https://github.com/chakra-ui/chakra-ui/issues/5554#issuecomment-1128385174

## Screenshots

Here you can see that the new key is used to detect the color mode
![image](https://github.com/BearStudio/start-ui-web/assets/7521065/92cc84e0-ce6b-459a-aabe-2787383c9458)

## Checklist

 - [x] I performed a self review of my code
 - [x] I ensured that everything is written in English
 - [x] I tested the feature or fix on my local environment
 - [ ] I ran the `yarn storybook` command and everything is working
 - [ ] If applicable, I updated the translations for english and french files  
      (If you cannot update the french language, just let us know in the PR description)
 - [x] If applicable, I updated the README.md
 - [ ] If applicable, I created a PR or an issue on the [documentation repository](https://github.com/bearstudio/start-ui-web-docs/)
 - [x] If applicable, I’m sure that my feature or my component is mobile first and available correctly on desktop




