### PR TITLE
Feat - Handle basic date formatting using i18n

### DIFF
--- a/src/lib/i18n/config.ts
+++ b/src/lib/i18n/config.ts
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 import i18n from 'i18next';
+import { isDate } from 'lodash';
 import { initReactI18next } from 'react-i18next';
 
 import {
@@ -10,6 +11,8 @@ import {
 import { isBrowser } from '@/lib/ssr';
 import locales from '@/locales';
 
+import { formatDate, minutesToHours } from './formatters';
+
 dayjs.locale(DEFAULT_LANGUAGE_KEY);
 
 i18n.use(initReactI18next).init({
@@ -18,13 +21,29 @@ i18n.use(initReactI18next).init({
   resources: locales,
   lng: DEFAULT_LANGUAGE_KEY,
   fallbackLng: DEFAULT_LANGUAGE_KEY,
-
   // Fix issue with i18next types
   // https://www.i18next.com/overview/typescript#argument-of-type-defaulttfuncreturn-is-not-assignable-to-parameter-of-type-xyz
   returnNull: false,
 
   interpolation: {
     escapeValue: false, // react already safes from xss
+    format: (value, format) => {
+      /* Default date formatter */
+      if (isDate(value)) {
+        return formatDate(value, format);
+      }
+
+      /**  List of custom formatters
+       *
+       * Declare your custom formatters in './formatters'
+       * And use them here
+       */
+      if (format === 'minutesToHours') {
+        return minutesToHours(value);
+      }
+
+      return value;
+    },
   },
 });
 

--- a/src/lib/i18n/formatters.ts
+++ b/src/lib/i18n/formatters.ts
@@ -1,0 +1,19 @@
+import dayjs from 'dayjs';
+
+const MINUTES_IN_AN_HOUR = 60;
+
+/**
+ *   Default Date formatter uses dayjs.
+ *
+ *   To see supported dayjs date format : https://day.js.org/docs/en/display/format
+ */
+export const formatDate = (date: Date, format?: string) => {
+  return dayjs(date).format(format);
+};
+
+/* Custom formatter Example */
+export const minutesToHours = (minutes: string | number) => {
+  return typeof minutes === 'string'
+    ? Number(minutes) / MINUTES_IN_AN_HOUR
+    : minutes / MINUTES_IN_AN_HOUR;
+};


### PR DESCRIPTION
## Describe your changes

closes #391

Following the code snippet given by @yoannfleurydev, I implemented a default date formatter and displayed the possibility to create cutom ones inside the `formatters.ts` file

For the default date formatter, I decided to use dayjs since it was already used in Start UI and because it provides a simple and easy-to-use format function.

## Screenshots
Usage in the code : 
![code](https://github.com/BearStudio/start-ui-web/assets/135032615/7b028918-661f-4600-8f74-3aa39294af26)

Result :
![result](https://github.com/BearStudio/start-ui-web/assets/135032615/a03cd2f5-514a-4c3d-9b45-dd6b78af93b6)


## Checklist

 - [x] I performed a self review of my code
 - [x] I ensured that everything is written in English
 - [x] I tested the feature or fix on my local environment
 - [x] I ran the `yarn storybook` command and everything is working


