### PR TITLE
feat: change script name for lint:next because using next cli

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -52,8 +52,8 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Eslint
-        run: pnpm lint:eslint
+      - name: NextJS Linting
+        run: pnpm lint:next
 
       - name: TypeScript check
         run: pnpm lint:ts

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "start": "next start",
     "pretty": "prettier -w .",
     "lint": "run-p lint:*",
-    "lint:eslint": "SKIP_ENV_VALIDATION=true next lint",
+    "lint:next": "SKIP_ENV_VALIDATION=true next lint",
     "lint:ts": "pnpm build:info && tsc --noEmit",
     "storybook": "pnpm build:info && storybook dev --no-open -p 6006",
     "storybook:build": "pnpm build:info && storybook build && mv ./storybook-static ./public/storybook",


### PR DESCRIPTION
## Describe your changes

change the name of the script because using nextjs linter (which may be or may not be eslint)

## Documentation

<!-- Please provide a link to the issue or PR of the documentation (https://docs.web.start-ui.com) if applicable -->

## Checklist

 - [x] I performed a self review of my code
 - [x] I ensured that everything is written in English
 - [x] I tested the feature or fix on my local environment
 - [ ] I ran the `pnpm storybook` command and everything is working
 - [ ] If applicable, I updated the translations for english and french files  
      (If you cannot update the french language, just let us know in the PR description)
 - [ ] If applicable, I updated the README.md
 - [ ] If applicable, I created a PR or an issue on the [documentation repository](https://github.com/bearstudio/start-ui-web-docs/)
 - [ ] If applicable, I’m sure that my feature or my component is mobile first and available correctly on desktop




