### PR TITLE
fix: daypicker format was changing on input blur

### DIFF
--- a/src/components/DayPicker/docs.stories.tsx
+++ b/src/components/DayPicker/docs.stories.tsx
@@ -91,3 +91,25 @@ export const WithoutPortal = () => {
     </Stack>
   );
 };
+
+export const Format = () => {
+  const [selectedDay, setSelectedDay] = useState<Date | null>();
+  const [defaultDay, setDefaultDay] = useState<Date | null>(new Date());
+
+  return (
+    <Stack spacing={2}>
+      <Text>Date : {JSON.stringify(selectedDay)}</Text>
+      <DayPicker
+        value={selectedDay}
+        onChange={setSelectedDay}
+        dateFormat="DD MMM YYYY"
+      />
+      <Text>Date : {JSON.stringify(defaultDay)}</Text>
+      <DayPicker
+        value={defaultDay}
+        onChange={setDefaultDay}
+        dateFormat="DD MMM YYYY"
+      />
+    </Stack>
+  );
+};

--- a/src/components/DayPicker/hooks/useDayPickerInputManagement.ts
+++ b/src/components/DayPicker/hooks/useDayPickerInputManagement.ts
@@ -55,7 +55,7 @@ export const useDayPickerInputManagement = (
         return;
       }
       setInputValue(
-        dateValueAsDayjs.isValid() ? dateValueAsDayjs.format(DATE_FORMAT) : ''
+        dateValueAsDayjs.isValid() ? dateValueAsDayjs.format(dateFormat) : ''
       );
       return;
     }


### PR DESCRIPTION
## Describe your changes

fix issue on the day picker. the format was changing on input blur

<!-- Please give some details about what you did and the way you did it -->

## Screenshots

### Before

https://github.com/BearStudio/start-ui-web/assets/3920615/27ab7bd1-6099-44d1-a285-1825f061126a

### After

https://github.com/BearStudio/start-ui-web/assets/3920615/3dfb85ad-48b0-4c20-9e91-530759e007d3


## Documentation

<!-- Please provide a link to the issue or PR of the documentation (https://docs.web.start-ui.com) if applicable -->

## Checklist

 - [x] I performed a self review of my code
 - [x] I ensured that everything is written in English
 - [x] I tested the feature or fix on my local environment
 - [x] I ran the `pnpm storybook` command and everything is working
 - [ ] If applicable, I updated the translations for english and french files  
      (If you cannot update the french language, just let us know in the PR description)
 - [ ] If applicable, I updated the README.md
 - [ ] If applicable, I created a PR or an issue on the [documentation repository](https://github.com/bearstudio/start-ui-web-docs/)
 - [ ] If applicable, I’m sure that my feature or my component is mobile first and available correctly on desktop




