### PR TITLE
fix: Prevent initial page to load twice

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,12 +1,12 @@
-import { ReactNode, Suspense } from 'react';
+import { ReactNode } from 'react';
 
 import { NextLoader } from '@/app/NextLoader';
 
 export default function AdminLayout({ children }: { children: ReactNode }) {
   return (
-    <Suspense>
+    <>
       <NextLoader lightColor="white" darkColor="white" />
       {children}
-    </Suspense>
+    </>
   );
 }

--- a/src/app/app/layout.tsx
+++ b/src/app/app/layout.tsx
@@ -1,12 +1,12 @@
-import { ReactNode, Suspense } from 'react';
+import { ReactNode } from 'react';
 
 import { NextLoader } from '@/app/NextLoader';
 
 export default function AppLayout({ children }: { children: ReactNode }) {
   return (
-    <Suspense>
+    <>
       <NextLoader showSpinner />
       {children}
-    </Suspense>
+    </>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, Suspense } from 'react';
+import { ReactNode } from 'react';
 
 import { Metadata } from 'next';
 
@@ -18,10 +18,8 @@ export default async function RootLayout({
 }) {
   return (
     <Document>
-      <Suspense>
-        <NextLoader />
-        {children}
-      </Suspense>
+      <NextLoader />
+      {children}
     </Document>
   );
 }


### PR DESCRIPTION
## Describe your changes

The first page loading in the browser was triggering a double reload (need to open a new tab to trigger, not only reload the page)
