### PR TITLE
Fix : FieldCurrency element overlapping on text

### DIFF
--- a/src/components/Form/FieldCurrency/index.tsx
+++ b/src/components/Form/FieldCurrency/index.tsx
@@ -68,8 +68,9 @@ export const FieldCurrency = <
               {...field}
               value={formatValue(field.value, 'from-cents')}
               onChange={(v) => field.onChange(formatValue(v, 'to-cents'))}
+              pl={!!props.startElement ? '2.5em' : ''}
+              pr={!!props.endElement ? '2.5em' : ''}
             />
-
             {!!props.startElement && (
               <InputLeftElement pointerEvents="none">
                 {props.startElement}

--- a/src/components/Form/FieldCurrency/index.tsx
+++ b/src/components/Form/FieldCurrency/index.tsx
@@ -68,8 +68,8 @@ export const FieldCurrency = <
               {...field}
               value={formatValue(field.value, 'from-cents')}
               onChange={(v) => field.onChange(formatValue(v, 'to-cents'))}
-              pl={!!props.startElement ? '2.5em' : ''}
-              pr={!!props.endElement ? '2.5em' : ''}
+              pl={props.startElement ? '2.5em' : undefined}
+              pr={props.endElement ? '2.5em' : undefined}
             />
             {!!props.startElement && (
               <InputLeftElement pointerEvents="none">


### PR DESCRIPTION
## Describe your changes

The start (and end) elements are overlapping on the FieldCurrency content.
This is because InputCurrency is made with a library other than ChakraUI and the stylings are not working together.
 To fix that, I added a padding to the InputCurrency inside of FieldCurrency if there is an element.

I tested the field with all 4 sizes of input ('xs', 'sm', 'md', lg') and in order it gives : 

![image](https://github.com/BearStudio/start-ui-web/assets/135032615/2d85e36d-5485-43b9-b7df-fce52d30e416)
![image](https://github.com/BearStudio/start-ui-web/assets/135032615/dc1df314-5320-4679-b4b2-0f85bc0f08aa)
![image](https://github.com/BearStudio/start-ui-web/assets/135032615/0e227427-af12-4ab1-a8eb-c210c3a2da17)
![image](https://github.com/BearStudio/start-ui-web/assets/135032615/044c1b7f-4626-4b46-ab4a-ca0b7c3b6163)

closes #474
## Checklist
 - [x] I performed a self review of my code
 - [x] I tested the feature or fix on my local environment
 - [x] I ran the `pnpm storybook` command and everything is working



