### PR TITLE
feat: add global stopPropagation for nested FormProviders 

### DIFF
--- a/src/components/Form/index.tsx
+++ b/src/components/Form/index.tsx
@@ -27,9 +27,14 @@ export const Form = <TFieldValues extends FieldValues>({
     <FormProvider {...props}>
       <form
         noValidate
-        onSubmit={
-          props.onSubmit ? props.handleSubmit(props.onSubmit) : undefined
-        }
+        onSubmit={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+
+          if (props.onSubmit) {
+            props.handleSubmit(props.onSubmit)(e);
+          }
+        }}
       >
         {props.children}
       </form>


### PR DESCRIPTION
## Describe your changes

Add `stopPropagation` to our custom `Form` component so nested Forms won't trigger parent forms.

Developers needs to handle the `Portal` to avoid DOM `form` in `form` themselves.

<!-- Please give some details about what you did and the way you did it -->


## Checklist

 - [x] I performed a self review of my code
 - [x] I ensured that everything is written in English
 - [x] I tested the feature or fix on my local environment
 - [x] I ran the `pnpm storybook` command and everything is working
 - [ ] If applicable, I updated the translations for english and french files  
      (If you cannot update the french language, just let us know in the PR description)
 - [ ] If applicable, I updated the README.md
 - [ ] If applicable, I created a PR or an issue on the [documentation repository](https://github.com/bearstudio/start-ui-web-docs/)
 - [ ] If applicable, I’m sure that my feature or my component is mobile first and available correctly on desktop




