### PR TITLE
feat: Add FormFieldErrorStandalone component

### DIFF
--- a/src/components/Form/FormField.tsx
+++ b/src/components/Form/FormField.tsx
@@ -27,6 +27,7 @@ type FieldCustomProps<
   type: 'custom';
   optionalityHint?: 'required' | 'optional' | false;
   isDisabled?: boolean;
+  displayError?: FormFieldContextValue['displayError'];
 } & Omit<ControllerProps<TFieldValues, TName>, 'disabled'>;
 
 export type FieldCommonProps<
@@ -39,7 +40,7 @@ export const FormField = <
   TFieldValues extends FieldValues = FieldValues,
   TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
 >(
-  props:
+  propsWithoutDefaults:
     | FieldCustomProps<TFieldValues, TName>
     | FieldTextProps<TFieldValues, TName>
     | FieldTextareaProps<TFieldValues, TName>
@@ -53,6 +54,11 @@ export const FormField = <
     | FieldRadiosProps<TFieldValues, TName>
   // -- ADD NEW FIELD PROPS TYPE HERE --
 ) => {
+  const props = {
+    displayError: true,
+    ...propsWithoutDefaults,
+  };
+
   const getField = () => {
     switch (props.type) {
       case 'custom':
@@ -100,8 +106,9 @@ export const FormField = <
       name: props.name,
       optionalityHint: props.optionalityHint,
       isDisabled: props.isDisabled,
+      displayError: props.displayError,
     }),
-    [props.name, props.optionalityHint, props.isDisabled]
+    [props.name, props.optionalityHint, props.isDisabled, props.displayError]
   );
 
   return (
@@ -118,6 +125,7 @@ type FormFieldContextValue<
   name: TName;
   optionalityHint?: 'required' | 'optional' | false;
   isDisabled?: boolean;
+  displayError?: boolean;
 };
 
 export const FormFieldContext = createContext<FormFieldContextValue | null>(

--- a/src/components/Form/FormFieldError.tsx
+++ b/src/components/Form/FormFieldError.tsx
@@ -5,13 +5,14 @@ import { LuAlertCircle } from 'react-icons/lu';
 
 import { Icon } from '@/components/Icons';
 
-import { useFormField } from './FormField';
+import { useFormField, useFormFieldContext } from './FormField';
 
 export const FormFieldError = forwardRef<
   ElementRef<typeof FormErrorMessage>,
   ComponentPropsWithoutRef<typeof FormErrorMessage>
 >(({ children, ...props }, ref) => {
   const { error } = useFormField();
+  const ctx = useFormFieldContext();
 
   if (!error && !children) {
     return null;
@@ -20,7 +21,9 @@ export const FormFieldError = forwardRef<
   if (!error) {
     return <FormHelperText m={0}>{children}</FormHelperText>;
   }
-
+  if (!ctx.displayError) {
+    return null;
+  }
   return (
     <FormErrorMessage m={0} ref={ref} {...props}>
       <SlideFade in offsetY={-6}>

--- a/src/components/Form/FormFieldErrorStandalone/docs.stories.tsx
+++ b/src/components/Form/FormFieldErrorStandalone/docs.stories.tsx
@@ -1,0 +1,99 @@
+import {
+  Alert,
+  AlertIcon,
+  AlertTitle,
+  Box,
+  Button,
+  SlideFade,
+  Stack,
+} from '@chakra-ui/react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+import { zu } from '@/lib/zod/zod-utils';
+
+import { Form, FormField } from '../';
+import { FormFieldErrorStandalone } from './';
+
+export default {
+  title: 'Form/FormFieldErrorStandalone',
+};
+
+type FormSchema = z.infer<ReturnType<typeof zFormSchema>>;
+const zFormSchema = () =>
+  z.object({
+    name: zu.string.nonEmpty(z.string(), {
+      required_error: 'Name is required',
+    }),
+  });
+
+const formOptions = {
+  mode: 'onBlur',
+  resolver: zodResolver(zFormSchema()),
+  defaultValues: {
+    name: '',
+  },
+} as const;
+
+export const Default = () => {
+  const form = useForm<FormSchema>(formOptions);
+
+  return (
+    <Form {...form} onSubmit={(values) => console.log(values)}>
+      <Stack spacing={4}>
+        <FormField
+          control={form.control}
+          type="text"
+          name="name"
+          label="Name"
+          placeholder="Placeholder"
+          helper="Render the error anywhere"
+          displayError={false}
+        />
+        <Box>
+          <Button type="submit" variant="@primary">
+            Submit
+          </Button>
+        </Box>
+        <FormFieldErrorStandalone control={form.control} name="name" />
+      </Stack>
+    </Form>
+  );
+};
+
+export const CustomRendering = () => {
+  const form = useForm<FormSchema>(formOptions);
+
+  return (
+    <Form {...form} onSubmit={(values) => console.log(values)}>
+      <Stack spacing={4}>
+        <FormField
+          control={form.control}
+          type="text"
+          name="name"
+          label="Name"
+          placeholder="Placeholder"
+          helper="Render the error anywhere with custom rendering"
+          displayError={false}
+        />
+        <Box>
+          <Button type="submit" variant="@primary">
+            Submit
+          </Button>
+        </Box>
+
+        <FormFieldErrorStandalone control={form.control} name="name">
+          {({ error }) => (
+            <SlideFade in offsetY={-6}>
+              <Alert status="error">
+                <AlertIcon />
+                <AlertTitle>{error?.message}</AlertTitle>
+              </Alert>
+            </SlideFade>
+          )}
+        </FormFieldErrorStandalone>
+      </Stack>
+    </Form>
+  );
+};

--- a/src/components/Form/FormFieldErrorStandalone/index.tsx
+++ b/src/components/Form/FormFieldErrorStandalone/index.tsx
@@ -1,0 +1,63 @@
+import { ElementRef, ReactNode } from 'react';
+
+import { Flex, FlexProps, SlideFade } from '@chakra-ui/react';
+import {
+  ControllerProps,
+  FieldError,
+  FieldPath,
+  FieldValues,
+} from 'react-hook-form';
+import { LuAlertCircle } from 'react-icons/lu';
+
+import { Icon } from '@/components/Icons';
+import { fixedForwardRef } from '@/lib/utils';
+
+type FormFieldErrorStandaloneProps<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = StrictUnion<
+  | (Omit<FlexProps, 'children'> &
+      Required<Pick<ControllerProps<TFieldValues, TName>, 'control' | 'name'>>)
+  | (Required<
+      Pick<ControllerProps<TFieldValues, TName>, 'control' | 'name'>
+    > & {
+      children: (params: { error?: FieldError }) => ReactNode;
+    })
+>;
+
+const FormFieldErrorStandaloneComponent = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>(
+  {
+    name,
+    control,
+    children,
+    ...props
+  }: FormFieldErrorStandaloneProps<TFieldValues, TName>,
+  ref: ElementRef<typeof Flex>
+) => {
+  const { error } = control.getFieldState(name);
+
+  if (!error) {
+    return null;
+  }
+
+  if (children) {
+    return children({ error });
+  }
+
+  return (
+    <SlideFade in offsetY={-6}>
+      <Flex fontSize="sm" color="error.500" ref={ref} {...props}>
+        <Icon icon={LuAlertCircle} me="2" />
+        {!!error?.message && <span>{error.message}</span>}
+      </Flex>
+    </SlideFade>
+  );
+};
+
+FormFieldErrorStandaloneComponent.displayName = 'FormFieldErrorStandalone';
+export const FormFieldErrorStandalone = fixedForwardRef(
+  FormFieldErrorStandaloneComponent
+);


### PR DESCRIPTION
## Describe your changes

Add the `<FormFieldErrorStandalone>` component to allows rendering error anywhere not only with the field. 
Add the `displayError`  props on FormField to allows to not display the error close to the field.

## Checklist

 - [x] I performed a self review of my code
 - [x] I ensured that everything is written in English
 - [x] I tested the feature or fix on my local environment
 - [x] I ran the `pnpm storybook` command and everything is working




