### PR TITLE
fix: don't create a session if user is not enabled

### DIFF
--- a/src/server/config/auth.ts
+++ b/src/server/config/auth.ts
@@ -34,6 +34,12 @@ export const getServerAuthSession = cache(async () => {
 
   const { user, session } = await lucia.validateSession(sessionId);
 
+  if (user?.accountStatus !== 'ENABLED')
+    return {
+      user: null,
+      session: null,
+    };
+
   try {
     if (session?.fresh) {
       const sessionCookie = lucia.createSessionCookie(session.id);


### PR DESCRIPTION
## Describe your changes

Prevent to create the session if the user is not ENABLED

## Checklist

 - [x] I performed a self review of my code
 - [x] I ensured that everything is written in English
 - [x] I tested the feature or fix on my local environment
 - [x] I ran the `pnpm storybook` command and everything is working
