### PR TITLE
fix: handle invalid state for field number

### DIFF
--- a/src/components/Form/FieldNumber/index.tsx
+++ b/src/components/Form/FieldNumber/index.tsx
@@ -71,7 +71,7 @@ export const FieldNumber = <
   return (
     <Controller
       {...props}
-      render={({ field }) => (
+      render={({ field, fieldState }) => (
         <Flex flexDirection="column" gap={1} flex={1} {...props.containerProps}>
           <InputGroup size={props.size}>
             <InputNumber
@@ -94,6 +94,7 @@ export const FieldNumber = <
               step={props.step}
               bigStep={props.bigStep}
               isDisabled={props.isDisabled}
+              isInvalid={!!fieldState.error}
               {...props.inputNumberProps}
               {...field}
               value={formatValue(field.value, 'from-cents')}


### PR DESCRIPTION
## Describe your changes

Add `fieldState.error` to make the input invalid when there are errors.

<!-- Please give some details about what you did and the way you did it -->

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/e7fd0cbf-495c-4609-96d8-7610aaa45659)

### After

![image](https://github.com/user-attachments/assets/ca528c41-a7b1-4dd7-a1a1-eaca5bac0134)

## Checklist

 - [x] I performed a self review of my code
 - [x] I ensured that everything is written in English
 - [x] I tested the feature or fix on my local environment
 - [x] I ran the `pnpm storybook` command and everything is working
 - [ ] If applicable, I updated the translations for english and french files  
      (If you cannot update the french language, just let us know in the PR description)
 - [ ] If applicable, I updated the README.md
 - [ ] If applicable, I created a PR or an issue on the [documentation repository](https://github.com/bearstudio/start-ui-web-docs/)
 - [x] If applicable, I’m sure that my feature or my component is mobile first and available correctly on desktop




