### PR TITLE
Fix : First item on pagination

### DIFF
--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -24,7 +24,7 @@ export const getPaginationInfo = ({
   pageSize = 10,
   totalItems = 0,
 }) => {
-  const firstItemOnPage = (page - 1) * pageSize + 1;
+  const firstItemOnPage = totalItems > 0 ? (page - 1) * pageSize + 1 : 0;
   const lastItemOnPage = Math.min(
     (page - 1) * pageSize + pageSize,
     totalItems ?? 0


### PR DESCRIPTION
## Describe your changes

<!-- Please provide the issue id if applicable, else remove the line -->
closes #279 

<!-- Please give some details about what you did and the way you did it -->
I put a condition on the `firstItemOnPage` props in Pagination component to display "Showing 0 to 0 of 0 results" instead of "Showing 1 to 0 of 0 results" when there is no result

## Screenshots

<!-- Please provide some screenshots if applicable -->
Result
![Capture d’écran du 2024-09-05 13-54-28](https://github.com/user-attachments/assets/31ae9189-1e62-4e6b-ade5-ed24d4f54f8e)
With these values
![Capture d’écran du 2024-09-05 14-08-26](https://github.com/user-attachments/assets/0d1a56e2-4712-4bac-b2d8-18635621ba78)

## Checklist

 - [x] I performed a self review of my code
 - [x] I ensured that everything is written in English
 - [x] I tested the feature or fix on my local environment
 - [x] I ran the `pnpm storybook` command and everything is working
 - [ ] If applicable, I updated the translations for english and french files  
      (If you cannot update the french language, just let us know in the PR description)
 - [ ] If applicable, I updated the README.md
 - [ ] If applicable, I created a PR or an issue on the [documentation repository](https://github.com/bearstudio/start-ui-web-docs/)
 - [x] If applicable, I’m sure that my feature or my component is mobile first and available correctly on desktop




