### PR TITLE
FEAT: development helper in env hint

### DIFF
--- a/src/components/DarkModeSwitch/index.tsx
+++ b/src/components/DarkModeSwitch/index.tsx
@@ -1,0 +1,46 @@
+import { useId } from 'react';
+
+import {
+  FormControl,
+  FormLabel,
+  HStack,
+  Switch,
+  useColorMode,
+} from '@chakra-ui/react';
+import { useTranslation } from 'react-i18next';
+
+export const DarkModeSwitch = () => {
+  const { t } = useTranslation(['account']);
+  const { colorMode, setColorMode } = useColorMode();
+  const id = useId();
+
+  return (
+    <FormControl display="flex" alignItems="center">
+      <HStack>
+        <FormLabel
+          as={colorMode === 'light' ? 'span' : undefined}
+          opacity={colorMode !== 'light' ? 0.5 : undefined}
+          htmlFor={id}
+          mb="0"
+          mr={0}
+        >
+          {t('account:preferences.theme.light')}
+        </FormLabel>
+        <Switch
+          colorScheme="brand"
+          id={id}
+          isChecked={colorMode === 'dark'}
+          onChange={(e) => setColorMode(e.target.checked ? 'dark' : 'light')}
+        />
+        <FormLabel
+          as={colorMode === 'dark' ? 'span' : undefined}
+          opacity={colorMode !== 'dark' ? 0.5 : undefined}
+          htmlFor={id}
+          mb="0"
+        >
+          {t('account:preferences.theme.dark')}
+        </FormLabel>
+      </HStack>
+    </FormControl>
+  );
+};

--- a/src/features/account/PageAccount.tsx
+++ b/src/features/account/PageAccount.tsx
@@ -1,4 +1,4 @@
-import React, { useId } from 'react';
+import React from 'react';
 
 import {
   Alert,
@@ -6,22 +6,18 @@ import {
   Box,
   Button,
   Divider,
-  FormControl,
-  FormLabel,
-  HStack,
   Heading,
   Link,
   LinkBox,
   LinkOverlay,
   Stack,
-  Switch,
-  useColorMode,
 } from '@chakra-ui/react';
 import { useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 import { LuArrowRight, LuLogOut, LuUser } from 'react-icons/lu';
 
 import { ConfirmModal } from '@/components/ConfirmModal';
+import { DarkModeSwitch } from '@/components/DarkModeSwitch';
 import { Icon } from '@/components/Icons';
 import { AccountDeleteButton } from '@/features/account/AccountDeleteButton';
 import { AccountEmailForm } from '@/features/account/AccountEmailForm';
@@ -117,39 +113,3 @@ export default function PageHome() {
     </AppLayoutPage>
   );
 }
-
-const DarkModeSwitch = () => {
-  const { t } = useTranslation(['account']);
-  const { colorMode, setColorMode } = useColorMode();
-  const id = useId();
-
-  return (
-    <FormControl display="flex" alignItems="center">
-      <HStack>
-        <FormLabel
-          as={colorMode === 'light' ? 'span' : undefined}
-          opacity={colorMode !== 'light' ? 0.5 : undefined}
-          htmlFor={id}
-          mb="0"
-          mr={0}
-        >
-          {t('account:preferences.theme.light')}
-        </FormLabel>
-        <Switch
-          colorScheme="brand"
-          id={id}
-          isChecked={colorMode === 'dark'}
-          onChange={(e) => setColorMode(e.target.checked ? 'dark' : 'light')}
-        />
-        <FormLabel
-          as={colorMode === 'dark' ? 'span' : undefined}
-          opacity={colorMode !== 'dark' ? 0.5 : undefined}
-          htmlFor={id}
-          mb="0"
-        >
-          {t('account:preferences.theme.dark')}
-        </FormLabel>
-      </HStack>
-    </FormControl>
-  );
-};

--- a/src/features/devtools/EnvHint.tsx
+++ b/src/features/devtools/EnvHint.tsx
@@ -1,6 +1,7 @@
 import { Box, Text } from '@chakra-ui/react';
 
 import { env } from '@/env.mjs';
+import { EnvHintDevPopover } from '@/features/devtools/EnvHintDevPopover';
 
 export const getEnvHintTitlePrefix = () => {
   if (env.NEXT_PUBLIC_ENV_EMOJI) return `${env.NEXT_PUBLIC_ENV_EMOJI} `;
@@ -13,6 +14,24 @@ export const EnvHint = () => {
     return null;
   }
 
+  const hintContent = (
+    <Text
+      position="fixed"
+      top="0"
+      insetStart="4"
+      bg={`${env.NEXT_PUBLIC_ENV_COLOR_SCHEME}.400`}
+      color={`${env.NEXT_PUBLIC_ENV_COLOR_SCHEME}.900`}
+      fontSize="0.6rem"
+      fontWeight="bold"
+      px="1"
+      borderBottomStartRadius="sm"
+      borderBottomEndRadius="sm"
+      textTransform="uppercase"
+    >
+      {env.NEXT_PUBLIC_ENV_NAME}
+    </Text>
+  );
+
   return (
     <Box
       zIndex="9999"
@@ -23,21 +42,11 @@ export const EnvHint = () => {
       h="2px"
       bg={`${env.NEXT_PUBLIC_ENV_COLOR_SCHEME}.400`}
     >
-      <Text
-        position="fixed"
-        top="0"
-        insetStart="4"
-        bg={`${env.NEXT_PUBLIC_ENV_COLOR_SCHEME}.400`}
-        color={`${env.NEXT_PUBLIC_ENV_COLOR_SCHEME}.900`}
-        fontSize="0.6rem"
-        fontWeight="bold"
-        px="1"
-        borderBottomStartRadius="sm"
-        borderBottomEndRadius="sm"
-        textTransform="uppercase"
-      >
-        {env.NEXT_PUBLIC_ENV_NAME}
-      </Text>
+      {env.NEXT_PUBLIC_NODE_ENV === 'development' ? (
+        <EnvHintDevPopover>{hintContent}</EnvHintDevPopover>
+      ) : (
+        hintContent
+      )}
     </Box>
   );
 };

--- a/src/features/devtools/EnvHintDevPopover.tsx
+++ b/src/features/devtools/EnvHintDevPopover.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { cloneElement } from 'react';
+
+import {
+  Popover,
+  PopoverArrow,
+  PopoverBody,
+  PopoverCloseButton,
+  PopoverContent,
+  PopoverHeader,
+  PopoverTrigger,
+} from '@chakra-ui/react';
+
+import { DarkModeSwitch } from '@/components/DarkModeSwitch';
+import { env } from '@/env.mjs';
+
+export const EnvHintDevPopover: React.FC<{ children: React.ReactElement }> = ({
+  children,
+}) => {
+  if (!env.NEXT_PUBLIC_ENV_NAME || !children) {
+    return null;
+  }
+
+  const childrenAsButton = cloneElement(children, { as: 'button' });
+
+  return (
+    <Popover closeOnBlur closeOnEsc>
+      <PopoverTrigger>{childrenAsButton}</PopoverTrigger>
+      <PopoverContent>
+        <PopoverArrow />
+        <PopoverCloseButton />
+        <PopoverHeader mb={2}>Development helper</PopoverHeader>
+        <PopoverBody>
+          <DarkModeSwitch />
+        </PopoverBody>
+      </PopoverContent>
+    </Popover>
+  );
+};


### PR DESCRIPTION
## Describe your changes

I create this PR as an idea, a proposal, it's a first draft to have some feedbacks.

The idea is to have a quick way to switch between light/dark modes during development, to avoid the pain to navigate to account page and then come back to our current page to try things on different theme mode.

This is the initial need, but maybe others use cases cause the same pain.

So I want to have a quick access to DarkModeSwitcher wherever we are in the app, and one stuff that is always display on development environnement is the EnvHint, that why I decide to improve it and transform it on a "development helper" opening button.


<!-- Please give some details about what you did and the way you did it -->

## Screenshots

![image](https://github.com/user-attachments/assets/4b64edd4-7f41-4c0b-9ec1-3d3b9be7babf)

## Documentation

<!-- Please provide a link to the issue or PR of the documentation (https://docs.web.start-ui.com) if applicable -->

## Checklist

 - [ ] I performed a self review of my code
 - [ ] I ensured that everything is written in English
 - [ ] I tested the feature or fix on my local environment
 - [ ] I ran the `pnpm storybook` command and everything is working
 - [ ] If applicable, I updated the translations for english and french files  
      (If you cannot update the french language, just let us know in the PR description)
 - [ ] If applicable, I updated the README.md
 - [ ] If applicable, I created a PR or an issue on the [documentation repository](https://github.com/bearstudio/start-ui-web-docs/)
 - [ ] If applicable, I’m sure that my feature or my component is mobile first and available correctly on desktop




