### PR TITLE
fix : clearable select and add a story in storybook

### DIFF
--- a/src/components/Form/FieldSelect/docs.stories.tsx
+++ b/src/components/Form/FieldSelect/docs.stories.tsx
@@ -12,7 +12,7 @@ export default {
 type FormSchema = z.infer<ReturnType<typeof zFormSchema>>;
 const zFormSchema = () =>
   z.object({
-    color: z.enum(['red', 'green', 'blue']),
+    color: z.enum(['red', 'green', 'blue']).nullish(),
   });
 
 const options = [
@@ -132,6 +132,35 @@ export const ChakraProps = () => {
                   backgroundColor: `${color}.100`,
                 }),
               },
+            }}
+          />
+        </FormField>
+        <Box>
+          <Button type="submit" variant="@primary">
+            Submit
+          </Button>
+        </Box>
+      </Stack>
+    </Form>
+  );
+};
+
+export const Clearable = () => {
+  const form = useForm<FormSchema>(formOptions);
+
+  return (
+    <Form {...form} onSubmit={(values) => console.log(values)}>
+      <Stack spacing={4}>
+        <FormField>
+          <FormFieldLabel>Colors</FormFieldLabel>
+          <FormFieldController
+            control={form.control}
+            type="select"
+            name="color"
+            placeholder="Placeholder"
+            options={options}
+            selectProps={{
+              isClearable: true,
             }}
           />
         </FormField>

--- a/src/components/Form/FieldSelect/index.tsx
+++ b/src/components/Form/FieldSelect/index.tsx
@@ -60,10 +60,17 @@ export const FieldSelect = <
               autoFocus={props.autoFocus}
               value={selectValue}
               isDisabled={props.isDisabled}
-              // @ts-expect-error should fix the typing. This error pops when
-              // we propagate the `selectProps`
-              onChange={(option) => onChange(option?.value)}
               {...props.selectProps}
+              onChange={(newValue, actionMeta) => {
+                if (actionMeta.action === 'clear') {
+                  // Set the value to null on clear
+                  onChange(null);
+                  return;
+                }
+                // @ts-expect-error TODO should fix the typing. This error pops when
+                // we propagate the `selectProps`
+                onChange(newValue?.value);
+              }}
               {...fieldProps}
             />
             <FormFieldError />


### PR DESCRIPTION
## Describe your changes

Fix the select with the clearable props. The value was not set to null when the field was cleared

## Screenshots

https://github.com/user-attachments/assets/3726b407-8961-44fc-bae9-4def318b3cb4



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a clearable color selection option in the form, allowing users to reset their choice.
	- Added a new documentation story demonstrating the clearable functionality.

- **Bug Fixes**
	- Enhanced the handling of the select input's clear action to ensure proper state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->