### PR TITLE
FIX/dot removing when last digit is erased

### DIFF
--- a/src/components/InputNumber/index.tsx
+++ b/src/components/InputNumber/index.tsx
@@ -78,6 +78,7 @@ export const InputNumber = forwardRef<InputNumberProps, 'input'>(
     });
     const [isFocused, setIsFocused] = useState(false);
     const tmpValueRef = useRef(value ?? defaultValue ?? null);
+    const [rawInput, setRawInput] = useState<string | undefined>(undefined);
 
     const handleOnKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
       const v = tmpValueRef.current;
@@ -104,10 +105,10 @@ export const InputNumber = forwardRef<InputNumberProps, 'input'>(
       prefix: `${currency ? currencyPrefix : ''}${prefix}`,
       onValueChange: (values) => {
         tmpValueRef.current = values.floatValue ?? null;
+        setRawInput(values.value);
 
         // Prevent -0 to be replaced with 0 when input is controlled
         if (values.floatValue === 0) return;
-
         onChange(values.floatValue ?? null);
       },
     } satisfies ComponentProps<typeof NumericFormat>;
@@ -120,7 +121,7 @@ export const InputNumber = forwardRef<InputNumberProps, 'input'>(
           pe={showButtons ? 8 : undefined}
           {...rest}
           {...getNumericFormatOptions}
-          value={value === undefined ? undefined : value ?? ''}
+          value={rawInput ?? (value === undefined ? undefined : value ?? '')}
           defaultValue={defaultValue ?? undefined}
           placeholder={
             typeof placeholder === 'number'


### PR DESCRIPTION
## Describe your changes

<!-- Please provide the issue id if applicable, else remove the line -->
closes #522 

<!-- Please give some details about what you did and the way you did it -->
I stored the string version of my value to keep the dot on display and make it priority on value formatted

## Screenshots

<!-- Please provide some screenshots if applicable -->
(can't see my cursor because of the recorder, but Im just clicking away, it formatting itself)

[Screencast from 2024-12-26 14-17-40.webm](https://github.com/user-attachments/assets/c6706510-8944-4968-ad8a-3754020ae21a)

## Checklist

 - [x] I performed a self review of my code
 - [x] I ensured that everything is written in English
 - [x] I tested the feature or fix on my local environment
 - [x] I ran the `pnpm storybook` command and everything is working
 - [x] If applicable, I created a PR or an issue on the [documentation repository](https://github.com/bearstudio/start-ui-web-docs/)
 - [x] If applicable, I’m sure that my feature or my component is mobile first and available correctly on desktop




