### PR TITLE
Fixing FieldMultiSelect ChakraProps part

### DIFF
--- a/src/components/Form/FieldMultiSelect/docs.stories.tsx
+++ b/src/components/Form/FieldMultiSelect/docs.stories.tsx
@@ -125,7 +125,6 @@ export const ChakraProps = () => {
             type="multi-select"
             name="colors"
             placeholder="Placeholder"
-            isDisabled
             options={options}
             selectProps={{
               chakraStyles: {


### PR DESCRIPTION
## Describe your changes

I just removed the isDisabled just below the placeholder. It prevented the user to effectively see the demonstration of ChakraProps in the component storybook.
See first screenshot for visual proof and second screenshot for the original code I modified in the push.
**Link to the file :** https://github.com/BearStudio/start-ui-web/blob/master/src/components/Form/FieldMultiSelect/docs.stories.tsx **line 128**

## Screenshots
![FieldMultiSelect ChakraProps unavailable](https://github.com/user-attachments/assets/a1b6529d-b78a-4499-89cb-4bab409d8b13)
![FieldMultiSelect Chalra Props disabled](https://github.com/user-attachments/assets/381277f3-723f-4d92-a57e-ba4e441228f1)


## Documentation

Not applicable here.

## Checklist

 - [ ] I performed a self review of my code
 - [ ] I ensured that everything is written in English
 - [ ] I tested the feature or fix on my local environment
 - [ ] I ran the `pnpm storybook` command and everything is working
 - [ ] If applicable, I updated the translations for english and french files  
      (If you cannot update the french language, just let us know in the PR description)
 - [ ] If applicable, I updated the README.md
 - [ ] If applicable, I created a PR or an issue on the [documentation repository](https://github.com/bearstudio/start-ui-web-docs/)
 - [ ] If applicable, I’m sure that my feature or my component is mobile first and available correctly on desktop




