### PR TITLE
fix: set cookie date to string conversion

### DIFF
--- a/src/server/config/trpc.ts
+++ b/src/server/config/trpc.ts
@@ -233,7 +233,7 @@ export const protectedProcedure = (
       if (token && req.method === 'GET') {
         resHeaders.append(
           'Set-Cookie',
-          `${AUTH_COOKIE_NAME}=${token}; Path=/; Expires=${session.expiresAt}; SameSite=Lax; HttpOnly; Secure=${env.NODE_ENV === 'production'}`
+          `${AUTH_COOKIE_NAME}=${token}; Path=/; Expires=${session.expiresAt.toISOString()}; SameSite=Lax; HttpOnly; Secure=${env.NODE_ENV === 'production'}`
         );
       }
 

--- a/src/server/config/trpc.ts
+++ b/src/server/config/trpc.ts
@@ -233,7 +233,7 @@ export const protectedProcedure = (
       if (token && req.method === 'GET') {
         resHeaders.append(
           'Set-Cookie',
-          `${AUTH_COOKIE_NAME}=${token}; Path=/; Expires=${session.expiresAt.toISOString()}; SameSite=Lax; HttpOnly; Secure=${env.NODE_ENV === 'production'}`
+          `${AUTH_COOKIE_NAME}=${token}; Path=/; Expires=${session.expiresAt.toUTCString()}; SameSite=Lax; HttpOnly; Secure=${env.NODE_ENV === 'production'}`
         );
       }
 


### PR DESCRIPTION
## Describe your changes
When working in local mode, the conversion of the session.expiresAt (a Date) value to a string when appending the Set-Cookie to the response headers caused an error. This would cause a fail any call to a route with a protectedProcedure.

Odly enough this is not a problem we see on the demo.
We suppose it is because vercel uses a different runtime (edge) on their servers.

## Screenshots
![image](https://github.com/user-attachments/assets/78c34172-73a8-4e42-9131-d19ae156d877)


## Documentation

<!-- Please provide a link to the issue or PR of the documentation (https://docs.web.start-ui.com) if applicable -->

## Checklist

 - [x] I performed a self review of my code
 - [x] I ensured that everything is written in English
 - [x] I tested the feature or fix on my local environment
 - [x] I ran the `pnpm storybook` command and everything is working





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the formatting of session expiration dates to use UTC string format, ensuring more reliable session management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->