### PR TITLE
V3: improve getUiState (when + error types)

### DIFF
--- a/app/features/user/manager/page-user.tsx
+++ b/app/features/user/manager/page-user.tsx
@@ -259,9 +259,9 @@ const UserSessions = (props: { userId: string }) => {
 
           <WithPermissions permissions={[{ session: ['revoke'] }]}>
             <DataListCell className="flex-none">
-              {ui.is('default') && (
+              {ui.when('default', () => (
                 <RevokeAllSessionsButton userId={props.userId} />
-              )}
+              ))}
             </DataListCell>
           </WithPermissions>
         </DataListRow>

--- a/app/lib/ui-state.ts
+++ b/app/lib/ui-state.ts
@@ -15,6 +15,18 @@ type UiState<
   state: {
     __status: Status;
   } & Data;
+  when: <
+    S extends Status,
+    SData = Omit<
+      Extract<UiState<Status, Data>['state'], { __status: S }>,
+      '__status'
+    >,
+  >(
+    status: S | Array<S>,
+    handler: (
+      data: SData
+    ) => React.ReactNode | ((...args: ExplicitAny[]) => React.ReactNode)
+  ) => React.ReactNode;
   match: <
     S extends Status,
     SData = Omit<
@@ -68,6 +80,16 @@ export const getUiState = <
     state,
     is: (status) => {
       return state.__status === status;
+    },
+    when: (status, handler) => {
+      if (
+        typeof status === 'string'
+          ? isMatching(status)
+          : isMatchingArray(status as Array<Status>)
+      ) {
+        return handler(state as ExplicitAny) as React.ReactNode;
+      }
+      return null;
     },
     match: (status, handler, __matched = false, render = () => null) => {
       if (


### PR DESCRIPTION
## Describe your changes

* Add `when`
* Add custom error types to improve DX
* Add possibility to autocomplete error stuff (ex: `exhaustive` even if all match are not setup), but trigger TS errors


<!-- Please give some details about what you did and the way you did it -->

## Screenshots

### `when`
![image](https://github.com/user-attachments/assets/e6fa157b-9449-467a-b5af-2ddf4394e2c6)

### `exhaustive` without `match`
![image](https://github.com/user-attachments/assets/7bc0631d-872f-434c-95e3-ae2b3954725e)

### `nonExhaustive` without `match`
![image](https://github.com/user-attachments/assets/e3248e22-4183-4758-8bb2-aa0c68a99046)

### Missing status matching with `exhaustive`
![image](https://github.com/user-attachments/assets/76ffd299-92e5-44ff-b5b1-3f74fb1bf366)

### Missing `exhaustive` or `nonExhaustive` after `match`
![image](https://github.com/user-attachments/assets/2d7aa569-bbcf-469a-836e-ecc4779154e5)



