### PR TITLE
fix: verbose prisma messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ That will scaffold a new folder with the latest version of 🚀 Start UI <small>
 
 # Install
 
-```
+```bash
 cp .env.example .env # Setup your env variables
 cp .vscode/settings.example.json .vscode/settings.json  # (Optionnal) Setup your VS Code
 pnpm install # Install dependencies
@@ -28,7 +28,7 @@ pnpm db:init # Init the db
 
 # Run
 
-```
+```bash
 pnpm dk:start # Only if your docker is not running
 pnpm dev
 ```

--- a/app/server/routers/book.ts
+++ b/app/server/routers/book.ts
@@ -151,8 +151,9 @@ export default {
           error.code === 'P2002'
         ) {
           throw new ORPCError('CONFLICT', {
-            message: error.message,
-            data: error.meta,
+            data: {
+              target: error.meta?.target,
+            },
           });
         }
         throw new ORPCError('INTERNAL_SERVER_ERROR');
@@ -198,8 +199,9 @@ export default {
           error.code === 'P2002'
         ) {
           throw new ORPCError('CONFLICT', {
-            message: error.message,
-            data: error.meta,
+            data: {
+              target: error.meta?.target,
+            },
           });
         }
         throw new ORPCError('INTERNAL_SERVER_ERROR');

--- a/app/server/routers/user.ts
+++ b/app/server/routers/user.ts
@@ -163,8 +163,9 @@ export default {
           error.code === 'P2002'
         ) {
           throw new ORPCError('CONFLICT', {
-            message: error.message,
-            data: error.meta,
+            data: {
+              target: error.meta?.target,
+            },
           });
         }
         throw new ORPCError('INTERNAL_SERVER_ERROR');
@@ -206,8 +207,9 @@ export default {
           error.code === 'P2002'
         ) {
           throw new ORPCError('CONFLICT', {
-            message: error.message,
-            data: error.meta,
+            data: {
+              target: error.meta?.target,
+            },
           });
         }
         throw new ORPCError('INTERNAL_SERVER_ERROR');


### PR DESCRIPTION
This PR improves the handling of Prisma `P2002` (unique constraint violation) errors
It now returns a ORPCError with the code CONFLICT and a data.target array indicating the conflicting field (e.g., email), without exposing the full error.meta from Prisma or message

before:
![image](https://github.com/user-attachments/assets/440199f4-3a03-48ef-8f34-c0c6c8d5e8b3)

after:
<img width="476" alt="image" src="https://github.com/user-attachments/assets/056b749b-f69e-497d-826a-cf6ad5e05f3e" />


No impact on the UI 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved syntax highlighting for shell commands in the README by specifying the bash language in code blocks.

* **Bug Fixes**
  * Enhanced error messages for unique constraint violations when creating or updating books and users, now displaying only relevant target information instead of full error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->