### PR TITLE
feat: add expo plugin and trusted origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,7 @@ DATABASE_URL="postgres://${DOCKER_DATABASE_USERNAME}:${DOCKER_DATABASE_PASSWORD}
 BETTER_AUTH_SECRET="REPLACE ME" # You can use `npx @better-auth/cli@latest secret` to a generated secret
 SESSION_EXPIRATION_IN_SECONDS=2592000 # 30 days
 SESSION_UPDATE_AGE_IN_SECONDS=86400 # 1 day (every 1 day the session expiration is updated)
-AUTH_TRUSTED_ORIGIN="start-ui-native://*" # Mobile app scheme for trustedOrigins config
+AUTH_TRUSTED_ORIGIN="start-ui-native://,start-ui-native://*" # Mobile app scheme for trustedOrigins config
 
 # GITHUB
 GITHUB_CLIENT_ID="REPLACE ME"

--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,7 @@ DATABASE_URL="postgres://${DOCKER_DATABASE_USERNAME}:${DOCKER_DATABASE_PASSWORD}
 BETTER_AUTH_SECRET="REPLACE ME" # You can use `npx @better-auth/cli@latest secret` to a generated secret
 SESSION_EXPIRATION_IN_SECONDS=2592000 # 30 days
 SESSION_UPDATE_AGE_IN_SECONDS=86400 # 1 day (every 1 day the session expiration is updated)
+AUTH_TRUSTED_ORIGIN="start-ui-native://*" # Mobile app scheme for trustedOrigins config
 
 # GITHUB
 GITHUB_CLIENT_ID="REPLACE ME"

--- a/app/env/server.ts
+++ b/app/env/server.ts
@@ -12,7 +12,7 @@ export const envServer = createEnv({
     BETTER_AUTH_SECRET: z.string(),
     SESSION_EXPIRATION_IN_SECONDS: z.coerce.number().int().default(2592000), // 30 days by default
     SESSION_UPDATE_AGE_IN_SECONDS: z.coerce.number().int().default(86400), // 1 day by default
-    AUTH_TRUSTED_ORIGIN: z.string(),
+    AUTH_TRUSTED_ORIGIN: z.string().optional(),
 
     GITHUB_CLIENT_ID: zOptionalWithReplaceMe(),
     GITHUB_CLIENT_SECRET: zOptionalWithReplaceMe(),

--- a/app/env/server.ts
+++ b/app/env/server.ts
@@ -12,6 +12,7 @@ export const envServer = createEnv({
     BETTER_AUTH_SECRET: z.string(),
     SESSION_EXPIRATION_IN_SECONDS: z.coerce.number().int().default(2592000), // 30 days by default
     SESSION_UPDATE_AGE_IN_SECONDS: z.coerce.number().int().default(86400), // 1 day by default
+    AUTH_TRUSTED_ORIGIN: z.string(),
 
     GITHUB_CLIENT_ID: zOptionalWithReplaceMe(),
     GITHUB_CLIENT_SECRET: zOptionalWithReplaceMe(),

--- a/app/locales/ar/auth.json
+++ b/app/locales/ar/auth.json
@@ -50,6 +50,7 @@
     "PASSWORD_TOO_SHORT": "كلمة المرور قصيرة جدًا",
     "PASSWORD_TOO_LONG": "كلمة المرور طويلة جدًا",
     "USER_ALREADY_EXISTS": "المستخدم موجود بالفعل",
+    "USER_ALREADY_HAS_PASSWORD": "المستخدم لديه كلمة مرور بالفعل",
     "EMAIL_CAN_NOT_BE_UPDATED": "لا يمكن تحديث البريد الإلكتروني",
     "CREDENTIAL_ACCOUNT_NOT_FOUND": "حساب بيانات الاعتماد غير موجود",
     "SESSION_EXPIRED": "انتهت صلاحية الجلسة. أعد المصادقة لتنفيذ هذا الإجراء.",

--- a/app/locales/en/auth.json
+++ b/app/locales/en/auth.json
@@ -93,6 +93,7 @@
     "PASSWORD_TOO_SHORT": "Password too short",
     "PASSWORD_TOO_LONG": "Password too long",
     "USER_ALREADY_EXISTS": "User already exists",
+    "USER_ALREADY_HAS_PASSWORD": "User already has password",
     "EMAIL_CAN_NOT_BE_UPDATED": "Email can not be updated",
     "CREDENTIAL_ACCOUNT_NOT_FOUND": "Credential account not found",
     "SESSION_EXPIRED": "Session expired. Re-authenticate to perform this action.",

--- a/app/locales/fr/auth.json
+++ b/app/locales/fr/auth.json
@@ -63,6 +63,7 @@
     "PASSWORD_TOO_SHORT": "Mot de passe trop court",
     "PASSWORD_TOO_LONG": "Mot de passe trop long",
     "USER_ALREADY_EXISTS": "L'utilisateur existe déjà",
+    "USER_ALREADY_HAS_PASSWORD": "L'utilisateur a déjà un mot de passe",
     "EMAIL_CAN_NOT_BE_UPDATED": "L'email ne peut pas être mis à jour",
     "CREDENTIAL_ACCOUNT_NOT_FOUND": "Compte d'identification non trouvé",
     "SESSION_EXPIRED": "Session expirée. Authentifiez-vous à nouveau pour effectuer cette action.",

--- a/app/locales/sw/auth.json
+++ b/app/locales/sw/auth.json
@@ -50,6 +50,7 @@
     "PASSWORD_TOO_SHORT": "Nenosiri fupi sana",
     "PASSWORD_TOO_LONG": "Nenosiri refu sana",
     "USER_ALREADY_EXISTS": "Mtumiaji tayari yupo",
+    "USER_ALREADY_HAS_PASSWORD": "Mtumiaji tayari ana nenosiri",
     "EMAIL_CAN_NOT_BE_UPDATED": "Barua pepe haiwezi kusasishwa",
     "CREDENTIAL_ACCOUNT_NOT_FOUND": "Akaunti ya kitambulisho haijapatikana",
     "SESSION_EXPIRED": "Kipindi kimeisha. Thibitisha tena ili kufanya kitendo hiki.",

--- a/app/server/auth.tsx
+++ b/app/server/auth.tsx
@@ -2,6 +2,7 @@ import { betterAuth } from 'better-auth';
 import { prismaAdapter } from 'better-auth/adapters/prisma';
 import { admin, emailOTP, openAPI } from 'better-auth/plugins';
 import { match } from 'ts-pattern';
+import { expo } from '@better-auth/expo';
 
 import i18n from '@/lib/i18n';
 
@@ -17,6 +18,7 @@ import { permissions } from '@/features/auth/permissions';
 import { db } from '@/server/db';
 import { sendEmail } from '@/server/email';
 import { getUserLanguage } from '@/server/utils';
+import { inferAdditionalFields } from 'better-auth/client/plugins';
 
 export type Auth = typeof auth;
 export const auth = betterAuth({
@@ -24,6 +26,7 @@ export const auth = betterAuth({
     expiresIn: envServer.SESSION_EXPIRATION_IN_SECONDS,
     updateAge: envServer.SESSION_UPDATE_AGE_IN_SECONDS,
   },
+  trustedOrigins: ['start-ui-native://', 'start-ui-native://*'],
   database: prismaAdapter(db, {
     provider: 'postgresql',
   }),
@@ -46,7 +49,9 @@ export const auth = betterAuth({
       disableImplicitSignUp: !AUTH_SIGNUP_ENABLED,
     },
   },
+
   plugins: [
+    expo(),
     openAPI({
       disableDefaultReference: true, // Use custom exposition in /routes/api/openapi folder
     }),

--- a/app/server/auth.tsx
+++ b/app/server/auth.tsx
@@ -25,7 +25,7 @@ export const auth = betterAuth({
     expiresIn: envServer.SESSION_EXPIRATION_IN_SECONDS,
     updateAge: envServer.SESSION_UPDATE_AGE_IN_SECONDS,
   },
-  // Allows an expo native app to use social auth, can be delete if no needed
+  // Allows an Expo native app to use social auth, can be delete if no needed
   trustedOrigins: envServer.AUTH_TRUSTED_ORIGIN
     ? envServer.AUTH_TRUSTED_ORIGIN.split(',')
     : undefined,
@@ -53,7 +53,7 @@ export const auth = betterAuth({
   },
 
   plugins: [
-    expo(),
+    expo(), // Allows an Expo native app to use auth, can be delete if no needed
     openAPI({
       disableDefaultReference: true, // Use custom exposition in /routes/api/openapi folder
     }),

--- a/app/server/auth.tsx
+++ b/app/server/auth.tsx
@@ -18,7 +18,6 @@ import { permissions } from '@/features/auth/permissions';
 import { db } from '@/server/db';
 import { sendEmail } from '@/server/email';
 import { getUserLanguage } from '@/server/utils';
-import { inferAdditionalFields } from 'better-auth/client/plugins';
 
 export type Auth = typeof auth;
 export const auth = betterAuth({

--- a/app/server/auth.tsx
+++ b/app/server/auth.tsx
@@ -1,8 +1,8 @@
+import { expo } from '@better-auth/expo';
 import { betterAuth } from 'better-auth';
 import { prismaAdapter } from 'better-auth/adapters/prisma';
 import { admin, emailOTP, openAPI } from 'better-auth/plugins';
 import { match } from 'ts-pattern';
-import { expo } from '@better-auth/expo';
 
 import i18n from '@/lib/i18n';
 
@@ -25,7 +25,7 @@ export const auth = betterAuth({
     expiresIn: envServer.SESSION_EXPIRATION_IN_SECONDS,
     updateAge: envServer.SESSION_UPDATE_AGE_IN_SECONDS,
   },
-  trustedOrigins: ['start-ui-native://', 'start-ui-native://*'],
+  trustedOrigins: [envServer.AUTH_TRUSTED_ORIGIN],
   database: prismaAdapter(db, {
     provider: 'postgresql',
   }),

--- a/app/server/auth.tsx
+++ b/app/server/auth.tsx
@@ -25,6 +25,7 @@ export const auth = betterAuth({
     expiresIn: envServer.SESSION_EXPIRATION_IN_SECONDS,
     updateAge: envServer.SESSION_UPDATE_AGE_IN_SECONDS,
   },
+  // Allows an expo native app to use social auth, can be delete if no needed
   trustedOrigins: [envServer.AUTH_TRUSTED_ORIGIN],
   database: prismaAdapter(db, {
     provider: 'postgresql',

--- a/app/server/auth.tsx
+++ b/app/server/auth.tsx
@@ -26,7 +26,9 @@ export const auth = betterAuth({
     updateAge: envServer.SESSION_UPDATE_AGE_IN_SECONDS,
   },
   // Allows an expo native app to use social auth, can be delete if no needed
-  trustedOrigins: [envServer.AUTH_TRUSTED_ORIGIN],
+  trustedOrigins: envServer.AUTH_TRUSTED_ORIGIN
+    ? envServer.AUTH_TRUSTED_ORIGIN.split(',')
+    : undefined,
   database: prismaAdapter(db, {
     provider: 'postgresql',
   }),

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@tanstack/react-start": "1.131.50",
     "@tanstack/zod-adapter": "1.131.50",
     "@uidotdev/usehooks": "2.4.1",
-    "better-auth": "1.2.7",
+    "better-auth": "1.2.10",
     "boring-avatars": "1.11.2",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@base-ui-components/react": "1.0.0-beta.1",
     "@bearstudio/ui-state": "1.0.2",
     "@fontsource-variable/inter": "5.2.6",
+    "@better-auth/expo": "1.2.10",
     "@headlessui/react": "2.2.2",
     "@hookform/resolvers": "5.0.1",
     "@orpc/client": "1.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 1.0.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@better-auth/expo':
         specifier: 1.2.10
-        version: 1.2.10(better-auth@1.2.7)
+        version: 1.2.10(better-auth@1.2.10)
       '@fontsource-variable/inter':
         specifier: 5.2.6
         version: 5.2.6
@@ -81,8 +81,8 @@ importers:
         specifier: 2.4.1
         version: 2.4.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       better-auth:
-        specifier: 1.2.7
-        version: 1.2.7
+        specifier: 1.2.10
+        version: 1.2.10
       boring-avatars:
         specifier: 1.11.2
         version: 1.11.2
@@ -617,8 +617,8 @@ packages:
     peerDependencies:
       better-auth: 1.2.10
 
-  '@better-auth/utils@0.2.4':
-    resolution: {integrity: sha512-ayiX87Xd5sCHEplAdeMgwkA0FgnXsEZBgDn890XHHwSWNqqRZDYOq3uj2Ei2leTv1I2KbG5HHn60Ah1i2JWZjQ==}
+  '@better-auth/utils@0.2.5':
+    resolution: {integrity: sha512-uI2+/8h/zVsH8RrYdG8eUErbuGBk16rZKQfz8CjxQOyCE6v7BqFYEbFwvOkvl1KbUdxhqOnXp78+uE5h8qVEgQ==}
 
   '@better-fetch/fetch@1.1.18':
     resolution: {integrity: sha512-rEFOE1MYIsBmoMJtQbl32PGHHXuG2hDxvEd7rUHE0vCBoFQVSDqaVs9hkZEtHCxRoY+CljXKFCOuJ8uxqw1LcA==}
@@ -3605,8 +3605,8 @@ packages:
     resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
     engines: {node: ^4.5.0 || >= 5.9}
 
-  better-auth@1.2.7:
-    resolution: {integrity: sha512-2hCB263GSrgetsMUZw8vv9O1e4S4AlYJW3P4e8bX9u3Q3idv4u9BzDFCblpTLuL4YjYovghMCN0vurAsctXOAQ==}
+  better-auth@1.2.10:
+    resolution: {integrity: sha512-nEj1RG4DdLUuJiV5CR93ORyPCptGRBwksaPPCkUtGo9ka+UIlTpaiKoTaTqVLLYlqwX4bOj9tJ32oBNdf2G3Kg==}
 
   better-call@1.0.9:
     resolution: {integrity: sha512-Qfm0gjk0XQz0oI7qvTK1hbqTsBY4xV2hsHAxF8LZfUYl3RaECCIifXuVqtPpZJWvlCCMlQSvkvhhyuApGUba6g==}
@@ -5363,9 +5363,9 @@ packages:
   kuler@2.0.0:
     resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
 
-  kysely@0.27.6:
-    resolution: {integrity: sha512-FIyV/64EkKhJmjgC0g2hygpBv5RNWVPyNCqSAD7eTCv6eFWNIi4PN1UvdSJGicN/o35bnevgis4Y0UDC0qi8jQ==}
-    engines: {node: '>=14.0.0'}
+  kysely@0.28.7:
+    resolution: {integrity: sha512-u/cAuTL4DRIiO2/g4vNGRgklEKNIj5Q3CG7RoUB5DV5SfEC2hMvPxKi0GWPmnzwL2ryIeud2VTcEEmqzTzEPNw==}
+    engines: {node: '>=20.0.0'}
 
   lambda-local@2.2.0:
     resolution: {integrity: sha512-bPcgpIXbHnVGfI/omZIlgucDqlf4LrsunwoKue5JdZeGybt8L6KyJz2Zu19ffuZwIwLj2NAI2ZyaqNT6/cetcg==}
@@ -8210,14 +8210,14 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@better-auth/expo@1.2.10(better-auth@1.2.7)':
+  '@better-auth/expo@1.2.10(better-auth@1.2.10)':
     dependencies:
       '@better-fetch/fetch': 1.1.18
-      better-auth: 1.2.7
+      better-auth: 1.2.10
       better-call: 1.0.9
       zod: 3.24.4
 
-  '@better-auth/utils@0.2.4':
+  '@better-auth/utils@0.2.5':
     dependencies:
       typescript: 5.8.3
       uncrypto: 0.1.3
@@ -11557,9 +11557,9 @@ snapshots:
 
   base64id@2.0.0: {}
 
-  better-auth@1.2.7:
+  better-auth@1.2.10:
     dependencies:
-      '@better-auth/utils': 0.2.4
+      '@better-auth/utils': 0.2.5
       '@better-fetch/fetch': 1.1.18
       '@noble/ciphers': 0.6.0
       '@noble/hashes': 1.7.1
@@ -11568,7 +11568,7 @@ snapshots:
       better-call: 1.0.9
       defu: 6.1.4
       jose: 5.10.0
-      kysely: 0.27.6
+      kysely: 0.28.7
       nanostores: 0.11.4
       zod: 3.24.4
 
@@ -13628,7 +13628,7 @@ snapshots:
 
   kuler@2.0.0: {}
 
-  kysely@0.27.6: {}
+  kysely@0.28.7: {}
 
   lambda-local@2.2.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@bearstudio/ui-state':
         specifier: 1.0.2
         version: 1.0.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@better-auth/expo':
+        specifier: 1.2.10
+        version: 1.2.10(better-auth@1.2.7)
       '@fontsource-variable/inter':
         specifier: 5.2.6
         version: 5.2.6
@@ -608,6 +611,11 @@ packages:
     peerDependencies:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
+
+  '@better-auth/expo@1.2.10':
+    resolution: {integrity: sha512-wMnYtDGF5W37Kuq7OY3/mudlWbbvxLMX0zoOMgB/icx3mReD6dv3hfpuVPoNQxT/dl/R+Rj7dvJ3b5Rk4CI3NA==}
+    peerDependencies:
+      better-auth: 1.2.10
 
   '@better-auth/utils@0.2.4':
     resolution: {integrity: sha512-ayiX87Xd5sCHEplAdeMgwkA0FgnXsEZBgDn890XHHwSWNqqRZDYOq3uj2Ei2leTv1I2KbG5HHn60Ah1i2JWZjQ==}
@@ -8201,6 +8209,13 @@ snapshots:
     dependencies:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
+
+  '@better-auth/expo@1.2.10(better-auth@1.2.7)':
+    dependencies:
+      '@better-fetch/fetch': 1.1.18
+      better-auth: 1.2.7
+      better-call: 1.0.9
+      zod: 3.24.4
 
   '@better-auth/utils@0.2.4':
     dependencies:


### PR DESCRIPTION
## Describe your changes
Add expo plugin and trusted origins to `better-auth` config, to make socials login works on start ui native using start ui web server




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Expo/native platform support for authentication, enabling social auth on mobile.
  * Introduced trusted origin(s) to improve auth flows for native apps.

* **Chores**
  * Added the Expo auth dependency.
  * Exposed a new AUTH_TRUSTED_ORIGIN configuration variable and updated environment examples and server settings.

* **Localization**
  * Added a new authentication error message "USER_ALREADY_HAS_PASSWORD" in English, French, Arabic, and Swahili.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->