### PR TITLE
feat: add pushduck as cloud-native upload alternative

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "nitro": "npm:nitro-nightly@3.0.1-20260219-081345-4df7aab2",
     "nodemailer": "7.0.13",
     "pino": "10.3.0",
+    "pushduck": "^0.4.0",
     "pino-pretty": "13.1.3",
     "react": "19.2.4",
     "react-day-picker": "9.13.0",

--- a/src/components/upload/pushduck-upload-button.tsx
+++ b/src/components/upload/pushduck-upload-button.tsx
@@ -15,7 +15,7 @@ import { Button } from '@/components/ui/button';
 
 import type { PushduckUploadRouter } from '@/server/pushduck';
 
-const { useUpload } = createUploadClient<PushduckUploadRouter>({
+const uploadClient = createUploadClient<PushduckUploadRouter>({
   endpoint: '/api/pushduck',
 });
 
@@ -43,14 +43,15 @@ export const PushduckUploadButton = ({
   const inputRef = useRef<HTMLInputElement>(null);
   const [isPending, setIsPending] = useState(false);
 
-  const { upload } = useUpload(uploadRoute, {
+  // uploadRoute is a stable prop — calling the typed hook via proxy is safe
+  const { uploadFiles } = uploadClient[uploadRoute]({
     onSuccess(results) {
       const result = results[0];
-      if (result) {
-        onSuccess?.(result);
+      if (result?.url) {
+        onSuccess?.({ url: result.url, key: result.key ?? result.url });
       }
     },
-    onError(err) {
+    onError(err: unknown) {
       onError?.(err instanceof Error ? err : new Error(String(err)));
     },
   });
@@ -61,7 +62,7 @@ export const PushduckUploadButton = ({
 
     setIsPending(true);
     try {
-      await upload([file]);
+      await uploadFiles([file]);
     } finally {
       setIsPending(false);
       event.target.value = '';

--- a/src/components/upload/pushduck-upload-button.tsx
+++ b/src/components/upload/pushduck-upload-button.tsx
@@ -1,0 +1,101 @@
+import { createUploadClient } from 'pushduck/client';
+import { UploadIcon } from 'lucide-react';
+import {
+  type ChangeEvent,
+  type ComponentProps,
+  type ReactElement,
+  useId,
+  useRef,
+  useState,
+} from 'react';
+
+import { cn } from '@/lib/tailwind/utils';
+
+import { Button } from '@/components/ui/button';
+
+import type { PushduckUploadRouter } from '@/server/pushduck';
+
+const { useUpload } = createUploadClient<PushduckUploadRouter>({
+  endpoint: '/api/pushduck',
+});
+
+export type PushduckRoutes = keyof PushduckUploadRouter;
+
+export type PushduckUploadButtonProps = {
+  uploadRoute: PushduckRoutes;
+  onSuccess?: (result: { url: string; key: string }) => void;
+  onError?: (error: Error) => void;
+  inputProps?: ComponentProps<'input'>;
+  icon?: ReactElement;
+} & Omit<ComponentProps<typeof Button>, 'onChange'>;
+
+export const PushduckUploadButton = ({
+  children,
+  inputProps,
+  onSuccess,
+  onError,
+  disabled,
+  icon,
+  uploadRoute,
+  ...rest
+}: PushduckUploadButtonProps) => {
+  const innerId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [isPending, setIsPending] = useState(false);
+
+  const { upload } = useUpload(uploadRoute, {
+    onSuccess(results) {
+      const result = results[0];
+      if (result) {
+        onSuccess?.(result);
+      }
+    },
+    onError(err) {
+      onError?.(err instanceof Error ? err : new Error(String(err)));
+    },
+  });
+
+  const handleFileChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    setIsPending(true);
+    try {
+      await upload([file]);
+    } finally {
+      setIsPending(false);
+      event.target.value = '';
+    }
+  };
+
+  return (
+    <>
+      <Button
+        size={!children ? 'icon' : undefined}
+        loading={isPending}
+        disabled={isPending || disabled}
+        onClick={() => inputRef.current?.click()}
+        onKeyDown={(keyboardEvent) => {
+          if (!['Enter', ' '].includes(keyboardEvent.key)) return;
+          keyboardEvent.preventDefault();
+          inputRef.current?.click();
+        }}
+        {...rest}
+      >
+        {!children ? (icon ?? <UploadIcon />) : children}
+      </Button>
+      <input
+        {...inputProps}
+        id={innerId}
+        ref={inputRef}
+        className={cn('hidden', inputProps?.className)}
+        type="file"
+        disabled={isPending || disabled}
+        onChange={(onChangeEvent) => {
+          handleFileChange(onChangeEvent);
+          inputProps?.onChange?.(onChangeEvent);
+        }}
+      />
+    </>
+  );
+};

--- a/src/routes/api/pushduck.ts
+++ b/src/routes/api/pushduck.ts
@@ -1,0 +1,38 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+import { envClient } from '@/env/client';
+import { auth } from '@/server/auth';
+import { uploadRouter } from '@/server/pushduck';
+
+export const Route = createFileRoute('/api/pushduck')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        if (envClient.VITE_IS_DEMO) {
+          return new Response('Demo Mode', { status: 405 });
+        }
+
+        const session = await auth.api.getSession(request);
+        if (!session?.user) {
+          return new Response('Unauthorized', { status: 401 });
+        }
+
+        const { GET } = uploadRouter.handlers;
+        return GET(request);
+      },
+      POST: async ({ request }) => {
+        if (envClient.VITE_IS_DEMO) {
+          return new Response('Demo Mode', { status: 405 });
+        }
+
+        const session = await auth.api.getSession(request);
+        if (!session?.user) {
+          return new Response('Unauthorized', { status: 401 });
+        }
+
+        const { POST } = uploadRouter.handlers;
+        return POST(request);
+      },
+    },
+  },
+});

--- a/src/server/pushduck.ts
+++ b/src/server/pushduck.ts
@@ -1,0 +1,22 @@
+import { createUploadConfig } from 'pushduck/server';
+
+import { envServer } from '@/env/server';
+
+const { s3 } = createUploadConfig()
+  .provider('minio', {
+    endpoint: envServer.S3_HOST,
+    accessKeyId: envServer.S3_ACCESS_KEY_ID,
+    secretAccessKey: envServer.S3_SECRET_ACCESS_KEY,
+    bucket: envServer.S3_BUCKET_NAME,
+    useSSL: envServer.S3_SECURE,
+  })
+  .build();
+
+export const uploadRouter = s3.createRouter({
+  bookCover: s3
+    .image()
+    .types(['image/png', 'image/jpeg', 'image/gif', 'image/webp'])
+    .maxFileSize('100MB'),
+});
+
+export type PushduckUploadRouter = typeof uploadRouter;


### PR DESCRIPTION
## Summary

- Adds `pushduck 0.4.0` as a cloud-native upload alternative that works alongside the existing `@better-upload` integration.
- **Reuses all existing `S3_*` env vars** — no new config required; works with self-hosted MinIO in development and any S3-compatible cloud provider in production.
- Follows the TanStack Start API route convention (`createFileRoute`) and the existing `better-auth` session guard pattern from `/api/upload`.

### Files added

| File | Purpose |
|---|---|
| `src/server/pushduck.ts` | Upload router config using the `minio` provider — maps `S3_*` env vars to pushduck's config |
| `src/routes/api/pushduck.ts` | TanStack Start API route at `/api/pushduck` — guards with better-auth session, delegates to pushduck handlers |
| `src/components/upload/pushduck-upload-button.tsx` | `<PushduckUploadButton>` — API-compatible drop-in for `<UploadButton>` using `pushduck/client` |

## Test plan

- [ ] Run `pnpm dev` — confirm the dev server starts and `/api/pushduck` route is registered.
- [ ] Use `<PushduckUploadButton uploadRoute="bookCover" />` in a page; confirm file is uploaded to MinIO bucket.
- [ ] Verify that an unauthenticated request to `POST /api/pushduck` returns `401 Unauthorized`.
- [ ] Confirm the existing `<UploadButton>` / `/api/upload` path is completely unaffected.
- [ ] Swap MinIO for an AWS S3 bucket by updating the `S3_*` env vars; confirm upload still works without code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added file upload with a visible upload button; supports PNG, JPEG, GIF, WebP and a 100MB max.
  * Uploads require user authentication and are disabled in demo mode; progress is shown and inputs are disabled during upload.

* **Chore**
  * Added new upload dependency to the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->