### PR TITLE
feat(ui): unify form control backgrounds

### DIFF
--- a/src/components/ui/alert.stories.tsx
+++ b/src/components/ui/alert.stories.tsx
@@ -1,5 +1,10 @@
 import { Meta } from '@storybook/react-vite';
-import { AlertCircleIcon, TerminalIcon } from 'lucide-react';
+import {
+  AlertCircleIcon,
+  CheckCircleIcon,
+  TerminalIcon,
+  TriangleAlertIcon,
+} from 'lucide-react';
 
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 
@@ -19,14 +24,37 @@ export const Default = () => {
   );
 };
 
-export const Destructive = () => {
+export const Variants = () => {
   return (
-    <Alert variant="destructive">
-      <AlertCircleIcon className="size-4" />
-      <AlertTitle>Error</AlertTitle>
-      <AlertDescription>
-        Your session has expired. Please log in again.
-      </AlertDescription>
-    </Alert>
+    <div className="flex flex-col gap-4">
+      <Alert>
+        <TerminalIcon className="size-4" />
+        <AlertTitle>Default</AlertTitle>
+        <AlertDescription>
+          You can add components to your app using the cli.
+        </AlertDescription>
+      </Alert>
+      <Alert variant="destructive">
+        <AlertCircleIcon className="size-4" />
+        <AlertTitle>Destructive</AlertTitle>
+        <AlertDescription>
+          Your session has expired. Please log in again.
+        </AlertDescription>
+      </Alert>
+      <Alert variant="warning">
+        <TriangleAlertIcon className="size-4" />
+        <AlertTitle>Warning</AlertTitle>
+        <AlertDescription>
+          Your subscription is about to expire.
+        </AlertDescription>
+      </Alert>
+      <Alert variant="positive">
+        <CheckCircleIcon className="size-4" />
+        <AlertTitle>Positive</AlertTitle>
+        <AlertDescription>
+          Your changes have been saved successfully.
+        </AlertDescription>
+      </Alert>
+    </div>
   );
 };

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -10,7 +10,11 @@ const alertVariants = cva(
       variant: {
         default: 'bg-card text-card-foreground',
         destructive:
-          'bg-card text-destructive *:data-[slot=alert-description]:text-destructive/90 [&>svg]:text-current',
+          'border-negative-200 bg-negative-50 text-negative-800 *:data-[slot=alert-description]:text-negative-900/80 dark:border-negative-900 dark:bg-negative-950/40 dark:text-negative-100 dark:*:data-[slot=alert-description]:text-negative-200/80',
+        warning:
+          'border-warning-200 bg-warning-50 text-warning-800 *:data-[slot=alert-description]:text-warning-900/80 dark:border-warning-900 dark:bg-warning-950/40 dark:text-warning-100 dark:*:data-[slot=alert-description]:text-warning-200/80',
+        positive:
+          'border-positive-200 bg-positive-50 text-positive-800 *:data-[slot=alert-description]:text-positive-900/80 dark:border-positive-900 dark:bg-positive-950/40 dark:text-positive-100 dark:*:data-[slot=alert-description]:text-positive-200/80',
       },
     },
     defaultVariants: {

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -61,8 +61,7 @@ export function Calendar({
   );
   const buttonNavClassName = buttonVariants({
     variant: 'secondary',
-    className:
-      'absolute h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100',
+    className: 'absolute h-7 w-7 p-0',
   });
   const _buttonNextClassName = cn(
     buttonNavClassName,
@@ -203,7 +202,7 @@ function Nav({ className }: NavProps) {
     <nav className={cn('flex items-center', className)}>
       <Button
         variant="secondary"
-        className="absolute left-0 h-7 w-7 bg-transparent p-0 opacity-80 hover:opacity-100"
+        className="absolute left-0 h-7 w-7 p-0"
         tabIndex={isPreviousDisabled ? undefined : -1}
         disabled={isPreviousDisabled}
         aria-label={labelPrevious(previousMonth)}
@@ -214,7 +213,7 @@ function Nav({ className }: NavProps) {
 
       <Button
         variant="secondary"
-        className="absolute right-0 h-7 w-7 bg-transparent p-0 opacity-80 hover:opacity-100"
+        className="absolute right-0 h-7 w-7 p-0"
         tabIndex={isNextDisabled ? undefined : -1}
         disabled={isNextDisabled}
         aria-label={labelNext(nextMonth)}

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -46,7 +46,7 @@ export function Calendar({
 
   const _monthsClassName = cn('relative flex', props.classNames?.months);
   const _monthCaptionClassName = cn(
-    'relative mx-10 flex h-7 items-center justify-center',
+    'relative mx-10 flex h-8 items-center justify-center',
     props.classNames?.month_caption
   );
   const _weekdaysClassName = cn('flex flex-row', props.classNames?.weekdays);
@@ -61,7 +61,8 @@ export function Calendar({
   );
   const buttonNavClassName = buttonVariants({
     variant: 'secondary',
-    className: 'absolute h-7 w-7 p-0',
+    size: 'icon-sm',
+    className: 'absolute',
   });
   const _buttonNextClassName = cn(
     buttonNavClassName,
@@ -202,7 +203,8 @@ function Nav({ className }: NavProps) {
     <nav className={cn('flex items-center', className)}>
       <Button
         variant="secondary"
-        className="absolute left-0 h-7 w-7 p-0"
+        size="icon-sm"
+        className="absolute left-0"
         tabIndex={isPreviousDisabled ? undefined : -1}
         disabled={isPreviousDisabled}
         aria-label={labelPrevious(previousMonth)}
@@ -213,7 +215,8 @@ function Nav({ className }: NavProps) {
 
       <Button
         variant="secondary"
-        className="absolute right-0 h-7 w-7 p-0"
+        size="icon-sm"
+        className="absolute right-0"
         tabIndex={isNextDisabled ? undefined : -1}
         disabled={isNextDisabled}
         aria-label={labelNext(nextMonth)}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<'div'>) {
     <div
       data-slot="card"
       className={cn(
-        'flex flex-col gap-2 rounded-sm border bg-card py-4 text-card-foreground',
+        'flex flex-col gap-2 rounded-lg border bg-card py-4 text-card-foreground',
         className
       )}
       {...props}

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -22,7 +22,7 @@ const labelVariants = cva(
 );
 
 const checkboxVariants = cva(
-  'flex flex-none cursor-pointer items-center justify-center rounded-sm outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-disabled:opacity-20 aria-invalid:focus-visible:ring-destructive/50 data-checked:bg-primary data-checked:text-primary-foreground data-disabled:cursor-not-allowed data-disabled:bg-muted-foreground data-indeterminate:border data-unchecked:border aria-invalid:data-unchecked:border-destructive',
+  'flex flex-none cursor-pointer items-center justify-center rounded-sm outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-disabled:opacity-20 aria-invalid:focus-visible:ring-destructive/50 data-checked:bg-primary data-checked:text-primary-foreground data-disabled:cursor-not-allowed data-disabled:bg-muted-foreground data-indeterminate:border data-indeterminate:bg-white data-unchecked:border data-unchecked:bg-white aria-invalid:data-unchecked:border-destructive dark:data-indeterminate:bg-input/30 dark:data-unchecked:bg-input/30',
   {
     variants: {
       size: {

--- a/src/components/ui/datalist.tsx
+++ b/src/components/ui/datalist.tsx
@@ -14,7 +14,7 @@ export const DataList = ({
   return (
     <div
       className={cn(
-        'relative flex w-full flex-col overflow-x-auto overflow-y-hidden rounded-sm border bg-white dark:bg-neutral-900',
+        'relative flex w-full flex-col overflow-x-auto overflow-y-hidden rounded-lg border bg-white dark:bg-neutral-900',
         className
       )}
       {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -31,7 +31,7 @@ function DialogOverlay({
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
-        'fixed inset-0 isolate z-50 bg-black/80 backdrop-blur-xs duration-100 data-closed:animate-out data-closed:fade-out-0 data-open:animate-in data-open:fade-in-0',
+        'fixed inset-0 isolate z-50 bg-black/30 backdrop-blur-xs duration-100 data-closed:animate-out data-closed:fade-out-0 data-open:animate-in data-open:fade-in-0',
         className
       )}
       {...props}

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -27,7 +27,7 @@ function DrawerOverlay({
     <DrawerPrimitive.Backdrop
       data-slot="drawer-overlay"
       className={cn(
-        'fixed inset-0 z-50 bg-black/80 supports-backdrop-filter:backdrop-blur-xs',
+        'fixed inset-0 z-50 bg-black/30 supports-backdrop-filter:backdrop-blur-xs',
         'opacity-[calc(1-var(--drawer-swipe-progress,0))] transition-opacity duration-450 ease-[cubic-bezier(0.32,0.72,0,1)]',
         'data-ending-style:opacity-0 data-starting-style:opacity-0',
         'data-ending-style:duration-[calc(var(--drawer-swipe-strength,1)*400ms)]',

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -53,7 +53,7 @@ function DropdownMenuContent({
         <MenuPrimitive.Popup
           data-slot="dropdown-menu-content"
           className={cn(
-            'z-50 max-h-(--available-height) min-w-[8rem] origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+            'z-50 max-h-(--available-height) min-w-[8rem] origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg border bg-popover p-1 text-popover-foreground shadow-md data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
             className
           )}
           {...props}
@@ -256,7 +256,7 @@ function DropdownMenuSubContent({
         <MenuPrimitive.Popup
           data-slot="dropdown-menu-sub-content"
           className={cn(
-            'z-50 min-w-[8rem] origin-(--transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+            'z-50 min-w-[8rem] origin-(--transform-origin) overflow-hidden rounded-lg border bg-popover p-1 text-popover-foreground shadow-lg data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
             className
           )}
           {...props}

--- a/src/components/ui/input-group.tsx
+++ b/src/components/ui/input-group.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/button';
 
 const inputGroupVariants = cva(
   cn(
-    'group/input-group relative flex w-full items-center rounded-md border border-input text-base shadow-xs transition-[color,box-shadow] outline-none dark:bg-input/30',
+    'group/input-group relative flex w-full items-center rounded-md border border-input bg-white text-base shadow-xs transition-[color,box-shadow] outline-none dark:bg-input/30',
     'min-w-0',
 
     // Input

--- a/src/components/ui/input-otp.tsx
+++ b/src/components/ui/input-otp.tsx
@@ -12,7 +12,7 @@ const InputOTPContext = React.createContext<
 
 const inputOTPVariants = cva(
   cn(
-    'relative flex items-center justify-center border-y border-e border-input text-base shadow-xs transition-all outline-none first:rounded-s-md first:border-s last:rounded-e-md aria-invalid:border-destructive data-[active=true]:z-10 data-[active=true]:border-ring data-[active=true]:ring-[3px] data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:border-destructive data-[active=true]:aria-invalid:ring-destructive/20 md:text-sm dark:data-[active=true]:aria-invalid:ring-destructive/40'
+    'relative flex items-center justify-center border-y border-e border-input bg-white text-base shadow-xs transition-all outline-none first:rounded-s-md first:border-s last:rounded-e-md aria-invalid:border-destructive data-[active=true]:z-10 data-[active=true]:border-ring data-[active=true]:ring-[3px] data-[active=true]:ring-ring/50 data-[active=true]:aria-invalid:border-destructive data-[active=true]:aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:data-[active=true]:aria-invalid:ring-destructive/40'
   ),
   {
     variants: {

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -35,7 +35,7 @@ function PopoverContent({
         <PopoverPrimitive.Popup
           data-slot="popover-content"
           className={cn(
-            'z-50 flex w-72 origin-(--transform-origin) flex-col gap-4 rounded-md bg-popover p-4 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+            'z-50 flex w-72 origin-(--transform-origin) flex-col gap-4 rounded-lg bg-popover p-4 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
             className
           )}
           initialFocus

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -23,7 +23,7 @@ const labelVariants = cva(
 );
 
 const radioVariants = cva(
-  'flex flex-none cursor-pointer items-center justify-center rounded-full outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:focus-visible:ring-destructive/50 data-checked:bg-primary data-checked:text-primary-foreground data-disabled:cursor-not-allowed data-disabled:bg-muted-foreground data-disabled:opacity-40 data-indeterminate:border data-unchecked:border aria-invalid:data-unchecked:border-destructive',
+  'flex flex-none cursor-pointer items-center justify-center rounded-full outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:focus-visible:ring-destructive/50 data-checked:bg-primary data-checked:text-primary-foreground data-disabled:cursor-not-allowed data-disabled:bg-muted-foreground data-disabled:opacity-40 data-indeterminate:border data-indeterminate:bg-white data-unchecked:border data-unchecked:bg-white aria-invalid:data-unchecked:border-destructive dark:data-indeterminate:bg-input/30 dark:data-unchecked:bg-input/30',
   {
     variants: {
       size: {

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -28,7 +28,7 @@ function SheetOverlay({ className, ...props }: SheetPrimitive.Backdrop.Props) {
     <SheetPrimitive.Backdrop
       data-slot="sheet-overlay"
       className={cn(
-        'fixed inset-0 z-50 bg-black/80 backdrop-blur-xs duration-300 data-closed:animate-out data-closed:fade-out-0 data-open:animate-in data-open:fade-in-0',
+        'fixed inset-0 z-50 bg-black/30 backdrop-blur-xs duration-300 data-closed:animate-out data-closed:fade-out-0 data-open:animate-in data-open:fade-in-0',
         className
       )}
       {...props}


### PR DESCRIPTION
Gives inputs, textareas, OTP slots, checkboxes and radios the same background as selects (`bg-white` in light mode, `dark:bg-input/30` in dark mode), scoped so checked/disabled fills are unaffected. Also makes the calendar month-navigation buttons match the standard secondary button by removing their `bg-transparent` override and opacity.

Generated with [Claude](https://claude.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Refined calendar month navigation sizing/positioning and adjusted month caption height.
  - Improved checkbox and radio visuals for unchecked/indeterminate states, including dark-mode background handling.
  - Standardized white backgrounds for input groups and OTP fields, with more consistent OTP invalid styling.
  - Increased corner radius consistency across cards, datalists, dropdown menus, and popovers.
  - Reduced dimming on dialog, drawer, and sheet backdrops for a lighter overlay.
- **New Features**
  - Expanded Alert variants to add warning and positive states, with updated destructive styling.
  - Updated Storybook to present multiple Alert variants in one consolidated view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->